### PR TITLE
Quiet history

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -183,6 +183,10 @@ impl Board {
         self.piece_at(mv.to())
     }
 
+    pub fn is_noisy(self, mv: &Move) -> bool {
+        mv.is_promo() || self.captured(mv).is_some()
+    }
+
     pub fn side_at(self, sq: u8) -> Option<Side> {
         if self.bb[White.idx()] & bits::bb(sq) != 0 { Some(White) }
         else if self.bb[Black.idx()] & bits::bb(sq) != 0 { Some(Black) }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,43 @@
+use crate::consts::Side;
+use crate::moves::Move;
+
+type FromToHistory<T> = [[T; 64]; 64];
+type PieceToHistory<T> = [[T; 64]; 6];
+
+pub struct QuietHistory {
+    entries: Box<[FromToHistory<i16>; 2]>,
+}
+
+impl QuietHistory {
+    const HISTORY_MAX: i16 = 16384;
+
+    pub fn new() -> Self {
+        QuietHistory {
+            entries: Box::new([[[0; 64]; 64], [[0; 64]; 64] ]),
+        }
+    }
+
+    pub fn get(&self, stm: Side, mv: Move) -> i16 {
+        self.entries[stm as usize][mv.from() as usize][mv.to() as usize]
+    }
+
+    pub fn update(&mut self, stm: Side, mv: Move, bonus: i16) {
+        let entry = &mut self.entries[stm as usize][mv.from() as usize][mv.to() as usize];
+        *entry = gravity(*entry, bonus, Self::HISTORY_MAX);
+    }
+
+
+    pub fn clear(&mut self) {
+        for entry in self.entries.iter_mut() {
+            for row in entry.iter_mut() {
+                for col in row.iter_mut() {
+                    *col = 0;
+                }
+            }
+        }
+    }
+}
+
+fn gravity(current: i16, update: i16, max: i16) -> i16 {
+    current + update - current * update.abs() / max
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -21,7 +21,7 @@ impl QuietHistory {
         self.entries[stm as usize][mv.from() as usize][mv.to() as usize]
     }
 
-    pub fn update(&mut self, stm: Side, mv: Move, bonus: i16) {
+    pub fn update(&mut self, stm: Side, mv: &Move, bonus: i16) {
         let entry = &mut self.entries[stm as usize][mv.from() as usize][mv.to() as usize];
         *entry = gravity(*entry, bonus, Self::HISTORY_MAX);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod zobrist;
 mod evaluate;
 mod ordering;
 mod tt;
+mod history;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src/ordering.rs
+++ b/src/ordering.rs
@@ -3,6 +3,9 @@ use crate::moves::{Move, MoveList, MAX_MOVES};
 use crate::thread::ThreadData;
 
 pub const TT_MOVE_BONUS: i32 = 1000000;
+pub const NOISY_BONUS: i32 = 500000;
+pub const QUIET_BONUS: i32 = 0;
+
 pub const MVV_LVA: [[u8; 7]; 7] = [
     [10, 11, 12, 13, 14, 15, 0], // victim P, attacker K, Q, R, B, N, P, ~
     [20, 21, 22, 23, 24, 25, 0], // victim N, attacker K, Q, R, B, N, P, ~
@@ -24,10 +27,10 @@ pub fn score(td: &ThreadData, board: &Board, moves: &MoveList, tt_move: &Move) -
             if let Some(v) = victim {
                 let attacker = board.piece_at(m.from());
                 if let Some(a) = attacker {
-                    scores[idx] = MVV_LVA[v as usize][a as usize] as i32;
+                    scores[idx] = NOISY_BONUS + MVV_LVA[v as usize][a as usize] as i32;
                 }
             } else {
-                scores[idx] = td.quiet_history.get(board.stm, *m) as i32;
+                scores[idx] = QUIET_BONUS + td.quiet_history.get(board.stm, *m) as i32;
             }
         }
         idx += 1;

--- a/src/ordering.rs
+++ b/src/ordering.rs
@@ -1,5 +1,6 @@
 use crate::board::Board;
 use crate::moves::{Move, MoveList, MAX_MOVES};
+use crate::thread::ThreadData;
 
 pub const TT_MOVE_BONUS: i32 = 1000000;
 pub const MVV_LVA: [[u8; 7]; 7] = [
@@ -12,7 +13,7 @@ pub const MVV_LVA: [[u8; 7]; 7] = [
     [0, 0, 0, 0, 0, 0, 0],       // victim ~, attacker K, Q, R, B, N, P, ~
 ];
 
-pub fn score(board: &Board, moves: &MoveList, tt_move: &Move) -> [i32; MAX_MOVES] {
+pub fn score(td: &ThreadData, board: &Board, moves: &MoveList, tt_move: &Move) -> [i32; MAX_MOVES] {
     let mut scores = [0; MAX_MOVES];
     let mut idx = 0;
     for m in moves.iter() {
@@ -25,6 +26,8 @@ pub fn score(board: &Board, moves: &MoveList, tt_move: &Move) -> [i32; MAX_MOVES
                 if let Some(a) = attacker {
                     scores[idx] = MVV_LVA[v as usize][a as usize] as i32;
                 }
+            } else {
+                scores[idx] = td.quiet_history.get(board.stm, *m) as i32;
             }
         }
         idx += 1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -119,6 +119,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
 
             if score >= beta {
                 flag = TTFlag::Upper;
+                td.quiet_history.update(board.stm, &mv, (120 * depth as i16 - 75).min(1200));
                 break;
             }
         }
@@ -127,18 +128,6 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
     // handle checkmate / stalemate
     if legals == 0 {
         return if in_check { ply as i32 - Score::Max as i32 } else { Score::Draw as i32 }
-    }
-
-    if best_score >= beta {
-        for quiet in quiet_moves {
-            let good = quiet == best_move;
-            let bonus: i16 = if good {
-                (120 * depth as i16 - 75).min(1200)
-            } else {
-                -(120 * depth as i16 - 75).min(1200)
-            };
-            td.quiet_history.update(board.stm, quiet, bonus);
-        }
     }
 
     if !root {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use std::time::Instant;
-
+use arrayvec::ArrayVec;
 use crate::board::Board;
 use crate::consts::{Score, MAX_DEPTH};
 use crate::movegen::{gen_moves, is_check, MoveFilter};
@@ -76,7 +76,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
     }
 
     let mut moves = gen_moves(board, MoveFilter::All);
-    let scores = score(&board, &moves, &tt_move);
+    let scores = score(&td, &board, &moves, &tt_move);
     moves.sort(&scores);
 
     let mut legals = 0;
@@ -84,15 +84,24 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
     let mut best_move = Move::NONE;
     let mut flag = TTFlag::Lower;
 
+    let mut quiet_moves = ArrayVec::<Move, 32>::new();
+
     for mv in moves.iter() {
         let mut board = *board;
         board.make(&mv);
         if is_check(&board, board.stm.flip()) {
             continue
         }
+        let captured = board.captured(&mv);
+        let is_quiet = captured.is_none();
         legals += 1;
         td.nodes += 1;
+
         let score = -alpha_beta(&board, td, depth - 1, ply + 1, -beta, -alpha);
+
+        if is_quiet {
+            quiet_moves.push(*mv);
+        }
 
         if td.abort() { break; }
 
@@ -118,6 +127,18 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
     // handle checkmate / stalemate
     if legals == 0 {
         return if in_check { ply as i32 - Score::Max as i32 } else { Score::Draw as i32 }
+    }
+
+    if best_score >= beta {
+        for quiet in quiet_moves {
+            let good = quiet == best_move;
+            let bonus: i16 = if good {
+                (120 * depth as i16 - 75).min(1200)
+            } else {
+                -(120 * depth as i16 - 75).min(1200)
+            };
+            td.quiet_history.update(board.stm, quiet, bonus);
+        }
     }
 
     if !root {
@@ -165,7 +186,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, mut beta: i32) -> i32 
 
     let filter = if in_check { MoveFilter::All } else { MoveFilter::Captures };
     let mut moves = gen_moves(board, filter);
-    let scores = score(&board, &moves, &tt_move);
+    let scores = score(&td, &board, &moves, &tt_move);
     moves.sort(&scores);
     let mut legals = 0;
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::board::Board;
 use crate::evaluate::Evaluator;
+use crate::history::QuietHistory;
 use crate::moves::Move;
 use crate::tt::TranspositionTable;
 
@@ -10,6 +11,7 @@ pub struct ThreadData {
     pub main: bool,
     pub tt: TranspositionTable,
     pub board_history: Vec<Board>,
+    pub quiet_history: QuietHistory,
     pub evaluator: Evaluator,
     pub time: Instant,
     pub time_limit: Duration,
@@ -29,6 +31,7 @@ impl ThreadData {
             main: true,
             tt: TranspositionTable::new(64),
             board_history: Vec::new(),
+            quiet_history: QuietHistory::new(),
             evaluator: Evaluator::new(),
             time: Instant::now(),
             time_limit: Duration::MAX,
@@ -47,6 +50,7 @@ impl ThreadData {
             main: true,
             tt: TranspositionTable::new(64),
             board_history: Vec::new(),
+            quiet_history: QuietHistory::new(),
             evaluator: Evaluator::new(),
             time: Instant::now(),
             time_limit: Duration::MAX,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -79,6 +79,8 @@ impl UCI {
 
     fn handle_ucinewgame(&mut self) {
         self.td.tt.clear();
+        self.td.board_history.clear();
+        self.td.quiet_history.clear();
     }
 
     fn handle_bench(&self) {


### PR DESCRIPTION
```
Elo   | 14.88 +- 9.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.31 (-2.20, 2.20) [0.00, 5.00]
Games | N: 4182 W: 2173 L: 1994 D: 15
Penta | [416, 6, 1156, 9, 504]
```
https://kelseyde.pythonanywhere.com/test/601/

bench 14676783
