### PR TITLE
Aspiration windows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 - [x] Transposition Table (sort TT move first now in move ordering)
 - [x] Butterfly history heuristic
 - [ ] PVS
-- [ ] Aspiration windows
+- [x] Aspiration windows
 - [ ] RFP
 - [ ] NMP
 - [ ] LMR (log formula is most principled ~ there are a number of adjustments you can experiment with)


### PR DESCRIPTION
```
Elo   | 431.67 +- 96.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.41 (-2.20, 2.20) [0.00, 5.00]
Games | N: 260 W: 240 L: 20 D: 0
Penta | [0, 0, 20, 0, 110]
```
https://kelseyde.pythonanywhere.com/test/604/

bench 10861439