### PR TITLE
Reverse futility pruning

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -2,7 +2,7 @@ use crate::board::Board;
 use crate::search::search;
 use crate::thread::ThreadData;
 
-const BENCH_DEPTH: u8 = 6;
+const BENCH_DEPTH: i32 = 6;
 
 const FENS: [&str; 50] = [
     "r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,5 @@
 
-pub const MAX_DEPTH: u8 = 255;
+pub const MAX_DEPTH: i32 = 255;
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum Score {

--- a/src/search.rs
+++ b/src/search.rs
@@ -102,7 +102,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut 
 
     let static_eval = if in_check {Score::Min as i32} else { td.evaluator.evaluate(&board) };
 
-    if !root && !in_check && depth <= 8 && - 80 * depth >= beta {
+    if !root && !in_check && depth <= 8 && static_eval - 80 * depth >= beta {
         return static_eval;
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -61,7 +61,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
 
 }
 
-fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut alpha: i32, mut beta: i32) -> i32 {
+fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut alpha: i32, mut beta: i32) -> i32 {
 
     // If search is aborted, exit immediately
     if td.abort() { return alpha }
@@ -83,7 +83,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
         match tt_entry {
             Some(entry) => {
                 tt_move = entry.best_move();
-                if entry.depth() >= depth {
+                if entry.depth() >= depth as u8 {
                     if entry.flag() == TTFlag::Exact {
                         return entry.score() as i32
                     } else if entry.flag() == TTFlag::Lower {
@@ -98,6 +98,12 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
             }
             None => {}
         }
+    }
+
+    let static_eval = if in_check {Score::Min as i32} else { td.evaluator.evaluate(&board) };
+
+    if !root && !in_check && depth <= 8 && - 80 * depth >= beta {
+        return static_eval;
     }
 
     let mut moves = gen_moves(board, MoveFilter::All);
@@ -156,7 +162,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: u8, ply: u8, mut al
     }
 
     if !root {
-        td.tt.insert(board.hash, &best_move, best_score, depth, flag);
+        td.tt.insert(board.hash, &best_move, best_score, depth as u8, flag);
     }
 
     best_score

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -17,8 +17,8 @@ pub struct ThreadData {
     pub time_limit: Duration,
     pub nodes: u64,
     pub node_limit: u64,
-    pub depth: u8,
-    pub depth_limit: u8,
+    pub depth: i32,
+    pub depth_limit: i32,
     pub best_move: Move,
     pub eval: i32,
 }
@@ -44,7 +44,7 @@ impl ThreadData {
         }
     }
 
-    pub fn with_depth_limit(depth: u8) -> Self {
+    pub fn with_depth_limit(depth: i32) -> Self {
         ThreadData {
             id: 0,
             main: true,


### PR DESCRIPTION
```
Elo   | 52.94 +- 20.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 992 W: 525 L: 375 D: 92
Penta | [63, 35, 219, 47, 132]
```
https://kelseyde.pythonanywhere.com/test/606/

bench 7033626