### PR TITLE
Null move pruning

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,8 @@
 - [x] Butterfly history heuristic
 - [ ] PVS
 - [x] Aspiration windows
-- [ ] RFP
-- [ ] NMP
+- [x] RFP
+- [x] NMP
 - [ ] LMR (log formula is most principled ~ there are a number of adjustments you can experiment with)
 - [ ] Killer moves
 - [ ] LMP

--- a/src/board.rs
+++ b/src/board.rs
@@ -137,6 +137,16 @@ impl Board {
         }
     }
 
+    pub fn make_null_move(&mut self) {
+        self.hm = 0;
+        self.stm = self.stm.flip();
+        self.hash = Zobrist::toggle_stm(self.hash);
+        if let Some(ep_sq) = self.ep_sq {
+            self.hash = Zobrist::toggle_ep(self.hash, ep_sq);
+            self.ep_sq = None;
+        }
+    }
+
     pub fn pawns(self, side: Side) -> u64 {
         self.bb[Piece::Pawn as usize] & self.bb[side.idx()]
     }
@@ -173,6 +183,22 @@ impl Board {
         self.bb[side.idx()]
     }
 
+    pub fn us(self) -> u64 {
+        self.bb[self.stm.idx()]
+    }
+
+    pub fn them(self) -> u64 {
+        self.bb[self.stm.flip().idx()]
+    }
+
+    pub fn our(self, piece: Piece) -> u64 {
+        self.bb[piece as usize] & self.bb[self.stm.idx()]
+    }
+
+    pub fn their(self, piece: Piece) -> u64 {
+        self.bb[piece as usize] & self.bb[self.stm.flip().idx()]
+    }
+
     pub fn piece_at(self, sq: u8) -> Option<Piece> {
         self.pcs[sq as usize]
     }
@@ -191,6 +217,10 @@ impl Board {
         if self.bb[White.idx()] & bits::bb(sq) != 0 { Some(White) }
         else if self.bb[Black.idx()] & bits::bb(sq) != 0 { Some(Black) }
         else { None }
+    }
+
+    pub fn has_non_pawns(self) -> bool {
+        self.our(Piece::King) | self.our(Piece::Pawn) != self.us()
     }
 
     pub fn rank(sq: u8) -> u8 {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -10,6 +10,12 @@ pub enum Score {
     Mate = 30000 - MAX_DEPTH as isize,
 }
 
+impl Score {
+    pub fn is_mate(score: i32) -> bool {
+        score.abs() >= Score::Mate as i32 - MAX_DEPTH
+    }
+}
+
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Piece {

--- a/src/search.rs
+++ b/src/search.rs
@@ -102,8 +102,29 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut 
 
     let static_eval = if in_check {Score::Min as i32} else { td.evaluator.evaluate(&board) };
 
-    if !root && !in_check && depth <= 8 && static_eval - 80 * depth >= beta {
+    if !root
+        && !in_check
+        && depth <= 8
+        && static_eval - 80 * depth >= beta {
         return static_eval;
+    }
+
+    if !root
+        && !in_check
+        && depth >= 3
+        && static_eval >= beta
+        && board.has_non_pawns() {
+
+        let mut board = *board;
+        board.make_null_move();
+        td.nodes += 1;
+
+        let score = -alpha_beta(&board, td, depth - 3, ply + 1, -beta, -beta + 1);
+
+        if score >= beta {
+            return score;
+        }
+
     }
 
     let mut moves = gen_moves(board, MoveFilter::All);

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -66,6 +66,10 @@ impl Zobrist {
         hash ^ SIDE_KEY
     }
 
+    pub fn toggle_null_move(hash: u64) -> u64 {
+        hash ^ SIDE_KEY
+    }
+
     fn piece_index(piece: Piece, side: Side) -> usize {
         piece as usize + if side == Side::White { 0 } else { 6 }
     }


### PR DESCRIPTION
```
Elo   | 41.47 +- 17.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.24 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1288 W: 643 L: 490 D: 155
Penta | [90, 52, 269, 81, 152]
```
https://kelseyde.pythonanywhere.com/test/607/

bench 4644586