### PR TITLE
Fix mate scores and flag handling

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,4 +1,5 @@
 use crate::board::Board;
+use crate::moves::Move;
 use crate::search::search;
 use crate::thread::ThreadData;
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -5,9 +5,9 @@ pub const MAX_DEPTH: i32 = 255;
 pub enum Score {
     #[default]
     Draw = 0,
-    Min = -30000,
-    Max = 30000,
-    Mate = 30000 - MAX_DEPTH as isize,
+    Max = 32767,
+    Min = -32767,
+    Mate = 32766
 }
 
 impl Score {

--- a/src/search.rs
+++ b/src/search.rs
@@ -176,7 +176,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut 
 
     // handle checkmate / stalemate
     if legals == 0 {
-        return if in_check { ply - Score::Max as i32 } else { Score::Draw as i32 }
+        return if in_check { ply - Score::Mate as i32 } else { Score::Draw as i32 }
     }
 
     if !root {


### PR DESCRIPTION
```
Elo   | 195.22 +- 42.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 320 W: 209 L: 46 D: 65
Penta | [3, 14, 33, 37, 73]
```
https://kelseyde.pythonanywhere.com/test/622/

bench 3936716