### PR TITLE
Late move reductions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - [x] Aspiration windows
 - [x] RFP
 - [x] NMP
-- [ ] LMR (log formula is most principled ~ there are a number of adjustments you can experiment with)
+- [x] LMR (log formula is most principled ~ there are a number of adjustments you can experiment with)
 - [ ] Killer moves
 - [ ] LMP
 - [ ] Futility pruning

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4,6 +4,7 @@ use crate::board::Board;
 use crate::evaluate::Evaluator;
 use crate::history::QuietHistory;
 use crate::moves::Move;
+use crate::search::LmrTable;
 use crate::tt::TranspositionTable;
 
 pub struct ThreadData {
@@ -12,6 +13,7 @@ pub struct ThreadData {
     pub tt: TranspositionTable,
     pub board_history: Vec<Board>,
     pub quiet_history: QuietHistory,
+    pub lmr: LmrTable,
     pub evaluator: Evaluator,
     pub time: Instant,
     pub time_limit: Duration,
@@ -32,6 +34,7 @@ impl ThreadData {
             tt: TranspositionTable::new(64),
             board_history: Vec::new(),
             quiet_history: QuietHistory::new(),
+            lmr: LmrTable::default(),
             evaluator: Evaluator::new(),
             time: Instant::now(),
             time_limit: Duration::MAX,
@@ -52,6 +55,7 @@ impl ThreadData {
             board_history: Vec::new(),
             quiet_history: QuietHistory::new(),
             evaluator: Evaluator::new(),
+            lmr: LmrTable::default(),
             time: Instant::now(),
             time_limit: Duration::MAX,
             nodes: 0,


### PR DESCRIPTION
```
Elo   | 10.42 +- 7.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 5072 W: 1774 L: 1622 D: 1676
Penta | [241, 532, 879, 602, 282]
```
https://kelseyde.pythonanywhere.com/test/624/

bench 4035769