### PR TITLE
Check extension

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -146,7 +146,12 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut 
         move_count += 1;
         td.nodes += 1;
 
-        let score = -alpha_beta(&board, td, depth - 1, ply + 1, -beta, -alpha);
+        let mut extension = 0;
+        if (in_check) {
+            extension = 1;
+        }
+
+        let score = -alpha_beta(&board, td, depth - 1 + extension, ply + 1, -beta, -alpha);
 
         if is_quiet {
             quiet_moves.push(*mv);


### PR DESCRIPTION
```
Elo   | 20.77 +- 11.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2294 W: 842 L: 705 D: 747
Penta | [91, 241, 409, 252, 154]
```
https://kelseyde.pythonanywhere.com/test/627/

bench 4415295