### PR TITLE
Update correct stm in quiet history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -194,10 +194,13 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: i32, mut 
 
             if score >= beta {
                 flag = TTFlag::Lower;
-                td.quiet_history.update(board.stm, &mv, (120 * depth as i16 - 75).min(1200));
                 break;
             }
         }
+    }
+
+    if best_move.exists() {
+        td.quiet_history.update(board.stm, &best_move, (120 * depth as i16 - 75).min(1200));
     }
 
     // handle checkmate / stalemate


### PR DESCRIPTION
```
Elo   | 9.15 +- 8.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 3836 W: 1345 L: 1244 D: 1247
Penta | [173, 428, 672, 415, 230]
```
https://kelseyde.pythonanywhere.com/test/806/

bench 1385896