### PR TITLE
No pre-moveloop pruning in PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -104,7 +104,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         }
     }
 
-    let static_eval = if in_check {Score::MIN} else { td.nnue.evaluate(&board) };
+    let static_eval = if in_check { Score::MIN } else { td.nnue.evaluate(&board) };
 
     if !root_node && !pv_node && !in_check {
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -106,7 +106,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
 
     let static_eval = if in_check {Score::MIN} else { td.nnue.evaluate(&board) };
 
-    if !root_node && !in_check {
+    if !root_node && !pv_node && !in_check {
 
         if depth <= 8
             && static_eval - 80 * depth >= beta {
@@ -237,7 +237,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
 
     // handle checkmate / stalemate
     if move_count == 0 {
-        return if in_check { -(Score::MATE) + ply as i32} else { Score::DRAW }
+        return if in_check { -Score::MATE + ply as i32} else { Score::DRAW }
     }
 
     if !root_node {


### PR DESCRIPTION
```
Elo   | 131.80 +- 33.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 428 W: 260 L: 105 D: 63
Penta | [13, 14, 68, 43, 76]
```
https://kelseyde.pythonanywhere.com/test/849/

bench 1937105 