### PR TITLE
Futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -151,6 +151,15 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         let captured = board.captured(&mv);
         let is_quiet = captured.is_none();
 
+
+        // if !pv_node
+        //     && !in_check
+        //     && is_quiet
+        //     && depth < 6
+        //     && static_eval + 100 * depth + 150 <= alpha {
+        //     continue;
+        // }
+
         if !pv_node
             && depth <= 8
             && is_quiet

--- a/src/search.rs
+++ b/src/search.rs
@@ -150,12 +150,14 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         let pc = board.piece_at(mv.from());
         let captured = board.captured(&mv);
         let is_quiet = captured.is_none();
+        let is_mate_score = Score::is_mate(best_score);
 
         if !pv_node
             && !root_node
             && !in_check
             && is_quiet
             && depth < 6
+            && !is_mate_score
             && static_eval + 100 * depth.max(1) + 150 <= alpha {
             continue;
         }
@@ -163,7 +165,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         if !pv_node
             && depth <= 8
             && is_quiet
-            && !Score::is_mate(best_score)
+            && !is_mate_score
             && !see(&board, &mv, -56 * depth) {
             continue;
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -151,14 +151,14 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         let captured = board.captured(&mv);
         let is_quiet = captured.is_none();
 
-
-        // if !pv_node
-        //     && !in_check
-        //     && is_quiet
-        //     && depth < 6
-        //     && static_eval + 100 * depth + 150 <= alpha {
-        //     continue;
-        // }
+        if !pv_node
+            && !root_node
+            && !in_check
+            && is_quiet
+            && depth < 6
+            && static_eval + 100 * depth + 150 <= alpha {
+            continue;
+        }
 
         if !pv_node
             && depth <= 8

--- a/src/search.rs
+++ b/src/search.rs
@@ -156,7 +156,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             && !in_check
             && is_quiet
             && depth < 6
-            && static_eval + 100 * depth + 150 <= alpha {
+            && static_eval + 100 * depth.max(1) + 150 <= alpha {
             continue;
         }
 


### PR DESCRIPTION
```
Elo   | 5.92 +- 5.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 11512 W: 4516 L: 4320 D: 2676
Penta | [697, 1009, 2217, 1067, 766]
```
https://kelseyde.pythonanywhere.com/test/859/

bench 1458075