### PR TITLE
Log LMR

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -2,7 +2,7 @@ use crate::board::Board;
 use crate::search::search;
 use crate::thread::ThreadData;
 
-const BENCH_DEPTH: i32 = 8;
+const BENCH_DEPTH: i32 = 9;
 
 const FENS: [&str; 50] = [
     "r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",

--- a/src/search.rs
+++ b/src/search.rs
@@ -196,8 +196,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
 
         let mut score = Score::MIN;
         if depth >= 3 && move_count > 3 + root_node as i32 + pv_node as i32 && is_quiet {
-            let mut reduction = td.lmr.reduction(depth, move_count);
-            reduction -= pv_node as i32;
+            let reduction = td.lmr.reduction(depth, move_count);
 
             let reduced_depth = (new_depth - reduction).max(1).min(new_depth);
 


### PR DESCRIPTION
```
Elo   | 30.77 +- 13.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1370 W: 506 L: 385 D: 479
Penta | [38, 128, 262, 189, 68]
```
https://kelseyde.pythonanywhere.com/test/886/

bench 1496372