### PR TITLE
History malus

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -21,11 +21,11 @@ impl ContinuationHistory {
         }
     }
 
-    pub fn get(&self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece) -> i16 {
+    pub fn get(&self, prev_mv: Move, prev_pc: Piece, mv: &Move, pc: Piece) -> i16 {
         self.entries[prev_pc][prev_mv.to()][pc][mv.to()]
     }
 
-    pub fn update(&mut self, prev_mv: Move, prev_pc: Piece, mv: Move, pc: Piece, bonus: i16) {
+    pub fn update(&mut self, prev_mv: &Move, prev_pc: Piece, mv: &Move, pc: Piece, bonus: i16) {
         let entry = &mut self.entries[prev_pc][prev_mv.to()][pc][mv.to()];
         *entry = gravity(*entry, bonus, Self::MAX);
     }

--- a/src/ordering.rs
+++ b/src/ordering.rs
@@ -36,7 +36,7 @@ pub fn score(td: &ThreadData, board: &Board, moves: &MoveList, tt_move: &Move, p
                     if let Some(prev_mv) = td.ss[ply - 1].mv {
                         let pc = board.piece_at(mv.from()).unwrap();
                         if let Some(prev_pc) = td.ss[ply -1].pc {
-                            td.cont_history.get(prev_mv, prev_pc, *mv, pc) as i32
+                            td.cont_history.get(prev_mv, prev_pc, mv, pc) as i32
                         } else {
                             0
                         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -252,13 +252,15 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         let quiet_malus = (120 * depth as i16 - 75).min(1200);
 
         let cont_bonus = (120 * depth as i16 - 75).min(1200);
+        let cont_malus = (120 * depth as i16 - 75).min(1200);
 
         td.quiet_history.update(board.stm, &best_move, quiet_bonus);
-        update_continuation_history(td, ply, best_move, pc, cont_bonus);
+        update_continuation_history(td, ply, &best_move, pc, cont_bonus);
 
         for mv in quiet_moves.iter() {
             if mv != &best_move {
                 td.quiet_history.update(board.stm, mv, -quiet_malus);
+                update_continuation_history(td, ply, mv, pc, -cont_malus);
             }
         }
     }
@@ -374,11 +376,11 @@ fn is_draw(td: &ThreadData, board: &Board) -> bool {
     board.is_fifty_move_rule() || board.is_insufficient_material() || td.is_repetition(&board)
 }
 
-fn update_continuation_history(td: &mut ThreadData, ply: usize, mv: Move, pc: Piece, bonus: i16) {
+fn update_continuation_history(td: &mut ThreadData, ply: usize, mv: &Move, pc: Piece, bonus: i16) {
     for &prev_ply in &[1] {
         if prev_ply >= ply {
             if let (Some(prev_mv), Some(prev_pc)) = (td.ss[prev_ply].mv, td.ss[prev_ply].pc) {
-                td.cont_history.update(prev_mv, prev_pc, mv, pc, bonus);
+                td.cont_history.update(&prev_mv, prev_pc, mv, pc, bonus);
             }
         }
     }


### PR DESCRIPTION
```
Elo   | 4.51 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 15094 W: 5037 L: 4841 D: 5216
Penta | [634, 1574, 2946, 1748, 645]
```
https://kelseyde.pythonanywhere.com/test/888/

bench 1535574