### PR TITLE
Non-pawn correction history

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -18,6 +18,7 @@ pub struct Board {
     pub castle: u8,                // encoded castle rights
     pub hash: u64,                 // Zobrist hash
     pub pawn_hash: u64,            // Zobrist hash for pawns
+    pub non_pawn_hashes: [u64; 2]  // Zobrist hashes for non-pawns
 }
 
 impl Board {
@@ -28,7 +29,7 @@ impl Board {
 
     pub fn empty() -> Board {
         Board {
-            bb: [Bitboard::empty(); 8], pcs: [None; 64], stm: White, hm: 0, fm: 0, ep_sq: None, castle: 0, hash: 0, pawn_hash: 0
+            bb: [Bitboard::empty(); 8], pcs: [None; 64], stm: White, hm: 0, fm: 0, ep_sq: None, castle: 0, hash: 0, pawn_hash: 0, non_pawn_hashes: [0, 0]
         }
     }
 
@@ -70,6 +71,8 @@ impl Board {
         self.hash ^= Zobrist::sq(pc, side, sq);
         if pc == Pawn {
             self.pawn_hash ^= Zobrist::sq(Pawn, side, sq);
+        } else {
+            self.non_pawn_hashes[side] ^= Zobrist::sq(pc, side, sq);
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::board::Board;
-use crate::consts::{Piece, Score, MAX_DEPTH};
+use crate::consts::{Piece, Score, Side, MAX_DEPTH};
 use crate::movegen::{gen_moves, is_check, is_legal, MoveFilter};
 use crate::moves::Move;
 use crate::ordering::score;
@@ -283,6 +283,8 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         && !(flag == TTFlag::Lower && best_score <= static_eval)
         && (!best_move.exists() || !board.is_noisy(&best_move)) {
         td.pawn_corrhist.update(board.stm, board.pawn_hash, depth, static_eval, best_score);
+        td.nonpawn_corrhist[Side::White].update(board.stm, board.non_pawn_hashes[Side::White], depth, static_eval, best_score);
+        td.nonpawn_corrhist[Side::Black].update(board.stm, board.non_pawn_hashes[Side::Black], depth, static_eval, best_score);
     }
 
     if !root_node {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -100,6 +100,8 @@ impl ThreadData {
         self.quiet_history.clear();
         self.cont_history.clear();
         self.pawn_corrhist.clear();
+        self.nonpawn_corrhist[Side::White].clear();
+        self.nonpawn_corrhist[Side::Black].clear();
     }
 
     pub fn is_repetition(&self, board: &Board) -> bool {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::board::Board;
+use crate::consts::Side;
 use crate::history::{ContinuationHistory, CorrectionHistory, QuietHistory};
 use crate::moves::Move;
 use crate::network::NNUE;
@@ -19,6 +20,7 @@ pub struct ThreadData {
     pub quiet_history: QuietHistory,
     pub cont_history: ContinuationHistory,
     pub pawn_corrhist: CorrectionHistory,
+    pub nonpawn_corrhist: [CorrectionHistory; 2],
     pub lmr: LmrTable,
     pub limits: SearchLimits,
     pub start_time: Instant,
@@ -42,6 +44,7 @@ impl ThreadData {
             quiet_history: QuietHistory::new(),
             cont_history: ContinuationHistory::new(),
             pawn_corrhist: CorrectionHistory::new(),
+            nonpawn_corrhist: [CorrectionHistory::new(), CorrectionHistory::new()],
             lmr: LmrTable::default(),
             limits: SearchLimits::new(None, None, None, None, None),
             start_time: Instant::now(),
@@ -64,6 +67,7 @@ impl ThreadData {
             quiet_history: QuietHistory::new(),
             cont_history: ContinuationHistory::new(),
             pawn_corrhist: CorrectionHistory::new(),
+            nonpawn_corrhist: [CorrectionHistory::new(), CorrectionHistory::new()],
             lmr: LmrTable::default(),
             limits: SearchLimits::new(None, None, None, None, Some(depth as u64)),
             start_time: Instant::now(),
@@ -76,6 +80,8 @@ impl ThreadData {
 
     pub fn correction(&self, board: &Board) -> i32 {
         self.pawn_corrhist.get(board.stm, board.pawn_hash)
+        + self.nonpawn_corrhist[Side::White].get(board.stm, board.non_pawn_hashes[Side::White])
+        + self.nonpawn_corrhist[Side::Black].get(board.stm, board.non_pawn_hashes[Side::Black])
     }
 
     pub fn reset(&mut self) {

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -63,6 +63,21 @@ impl Zobrist {
         hash
     }
 
+    pub fn new_non_pawn_hashes(board: &Board) -> [u64; 2] {
+        let mut hashes: [u64; 2] = [0, 0];
+
+        for sq in Square::iter() {
+            if let Some(pc) = board.piece_at(sq) {
+                if pc != Pawn {
+                    let side = board.side_at(sq).unwrap();
+                    hashes[side] ^= Self::sq(pc, side, sq);
+                }
+            }
+        }
+
+        hashes
+    }
+
     pub fn sq(pc: Piece, side: Side, sq: Square) -> u64 {
         let piece_index = Zobrist::piece_index(pc, side);
         PIECE_KEYS[piece_index][sq]


### PR DESCRIPTION
```
Elo   | 10.55 +- 7.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 4514 W: 1521 L: 1384 D: 1609
Penta | [161, 482, 862, 563, 189]
```
https://chess.n9x.co/test/2512/