### PR TITLE
NMP depth-based reduction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@
 
 #### NMP
 - [x] NMP
-- [ ] NMP depth-based reduction
+- [x] NMP depth-based reduction
 - [ ] NMP eval-based reduction
 - [ ] NMP verification search
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -128,11 +128,12 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             && static_eval >= beta
             && board.has_non_pawns() {
 
+            let r = 3 + depth / 3;
             let mut board = *board;
             board.make_null_move();
             td.nodes += 1;
             td.keys.push(board.hash);
-            let score = -alpha_beta(&board, td, depth - 3, ply + 1, -beta, -beta + 1);
+            let score = -alpha_beta(&board, td, depth - r, ply + 1, -beta, -beta + 1);
             td.keys.pop();
 
             if score >= beta {


### PR DESCRIPTION
```
Elo   | 31.23 +- 13.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 1294 W: 480 L: 364 D: 450
Penta | [26, 129, 267, 153, 72]
```
https://chess.n9x.co/test/2527/

bench 1400947