### PR TITLE
Don't change a/b bounds on q-search TT hit

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -375,7 +375,7 @@ fn alpha_beta(
     best_score
 }
 
-fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, mut beta: i32, ply: usize) -> i32 {
+fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize) -> i32 {
     // If search is aborted, exit immediately
     if td.should_stop(Hard) {
         return alpha;
@@ -392,13 +392,8 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, mut beta: i32, ply: us
     if let Some(entry) = tt_entry {
         tt_move = entry.best_move();
         let score = entry.score(ply) as i32;
-        match entry.flag() {
-            TTFlag::Exact => return score,
-            TTFlag::Lower => alpha = alpha.max(score),
-            TTFlag::Upper => beta = beta.min(score),
-        }
 
-        if alpha >= beta {
+        if bounds_match(entry.flag(), score, alpha, beta) {
             return score;
         }
     }


### PR DESCRIPTION
Merging early because this was stupid in the first place

```
Elo   | 1.26 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 1.41 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 7430 W: 1921 L: 1894 D: 3615
Penta | [105, 906, 1682, 901, 121]
```
https://chess.n9x.co/test/2584/

bench 1453076