### PR TITLE
LMP skip quiets

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -198,6 +198,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             && is_quiet
             && depth <= 4
             && searched_moves > 4 + 3 * depth * depth {
+            move_picker.skip_quiets = true;
             continue;
         }
 


### PR DESCRIPTION
```
Elo   | 4.29 +- 3.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 11892 W: 3247 L: 3100 D: 5545
Penta | [174, 1431, 2639, 1478, 224]
```
https://chess.n9x.co/test/2691/

bench 1406731