### PR TITLE
HP skip quiets

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -212,6 +212,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             && is_quiet
             && depth <= 4
             && history_score < -2048 * depth * depth {
+            move_picker.skip_quiets = true;
             continue
         }
 


### PR DESCRIPTION
```
Elo   | 4.82 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 10306 W: 2839 L: 2696 D: 4771
Penta | [189, 1182, 2294, 1273, 215]
```
https://chess.n9x.co/test/2702/

bench 1350232