### PR TITLE
Negative extensions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,7 @@
 - [x] Singular extensions
 - [x] Double extensions
 - [ ] Triple extensions
-- [ ] Negative extensions
+- [x] Negative extensions
 - [ ] Double negative extensions
 - [ ] Multicut
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -274,6 +274,8 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             if score < s_beta {
                 extension = 1;
                 extension += (!pv_node && score < s_beta - 20) as i32;
+            } else if tt_score >= beta {
+                extension = -1;
             }
 
         }


### PR DESCRIPTION
```
Elo   | 6.40 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.23 (-2.20, 2.20) [0.00, 5.00]
Games | N: 6894 W: 1947 L: 1820 D: 3127
Penta | [113, 793, 1530, 876, 135]
```
https://chess.n9x.co/test/2761/

bench 2188955