### PR TITLE
LMR improving

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -299,10 +299,8 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         if depth >= 3 && searched_moves > 3 + root_node as i32 + pv_node as i32 && is_quiet {
             // Late Move Reductions
             let mut reduction = base_reduction;
-
-            if cut_node {
-                reduction += 1;
-            }
+            reduction += cut_node as i32;
+            reduction += !improving as i32;
 
             let reduced_depth = (new_depth - reduction).clamp(1, new_depth);
 


### PR DESCRIPTION
```
Elo   | 10.38 +- 6.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.25 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3882 W: 1092 L: 976 D: 1814
Penta | [61, 440, 849, 504, 87]
```
https://chess.n9x.co/test/2771/

bench 2028355