### PR TITLE
History LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -302,6 +302,9 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             let mut reduction = base_reduction;
             reduction += cut_node as i32;
             reduction += !improving as i32;
+            if is_quiet {
+                reduction -= (history_score - 512) / 16384;
+            }
 
             let reduced_depth = (new_depth - reduction).clamp(1, new_depth);
 


### PR DESCRIPTION
```
Elo   | 17.30 +- 9.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.20 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2130 W: 616 L: 510 D: 1004
Penta | [26, 241, 454, 289, 55]
```
https://chess.n9x.co/test/2780/

bench 1988944