### PR TITLE
Bad noisy pruning

### DIFF
--- a/src/movepicker.rs
+++ b/src/movepicker.rs
@@ -23,7 +23,7 @@ pub struct MovePicker {
     moves: MoveList,
     filter: MoveFilter,
     idx: usize,
-    stage: Stage,
+    pub stage: Stage,
     tt_move: Move,
     ply: usize,
     threats: Bitboard,

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,6 @@
 use crate::board::Board;
 use crate::movegen::{MoveFilter};
-use crate::movepicker::MovePicker;
+use crate::movepicker::{MovePicker, Stage};
 use crate::moves::Move;
 use crate::{movegen, see};
 use crate::see::see;
@@ -244,6 +244,16 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             && history_score < -2048 * depth * depth {
             move_picker.skip_quiets = true;
             continue
+        }
+
+        // Bad Noisy Pruning
+        let futility_margin = static_eval + 128 * lmr_depth;
+        if !pv_node
+            && !in_check
+            && lmr_depth < 6
+            && move_picker.stage == Stage::BadNoisies
+            && futility_margin <= alpha {
+            break;
         }
 
         // SEE Pruning


### PR DESCRIPTION
```
Elo   | 6.49 +- 5.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 6588 W: 1829 L: 1706 D: 3053
Penta | [102, 745, 1485, 852, 110]
```
https://chess.n9x.co/test/2784/

bench 1968473