### PR TITLE
Increase NMP reduction if TT move is noisy

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -106,6 +106,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
 
     let mut tt_hit = false;
     let mut tt_move = Move::NONE;
+    let mut tt_move_noisy = false;
     let mut tt_score = Score::MIN;
     let mut tt_flag = Lower;
     let mut tt_depth = 0;
@@ -119,6 +120,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             tt_flag = entry.flag();
             if can_use_tt_move(board, &entry.best_move()) {
                 tt_move = entry.best_move();
+                tt_move_noisy = board.is_noisy(&tt_move)
             }
 
             if !root_node
@@ -150,7 +152,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
 
         // Null Move Pruning
         if depth >= 3 && static_eval >= beta && board.has_non_pawns() {
-            let r = 3 + depth / 3 + ((static_eval - beta) / 210).min(4);
+            let r = 3 + depth / 3 + ((static_eval - beta) / 210).min(4) + tt_move_noisy as i32;
             let mut board = *board;
             board.make_null_move();
             td.nodes += 1;


### PR DESCRIPTION
```
Elo   | 3.23 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.34 (-2.20, 2.20) [0.00, 5.00]
Games | N: 20134 W: 5452 L: 5265 D: 9417
Penta | [307, 2372, 4559, 2485, 344]
```
https://chess.n9x.co/test/2812/

bench 1609471