### PR TITLE
Q-search futility pruning

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@
 - [X] QS SEE pruning
 - [x] PVS SEE quiet pruning 
 - [x] PVS SEE noisy pruning
-- [ ] QS futility pruning
+- [x] QS futility pruning
 - [ ] QS delta pruning
 - [x] History pruning
 - [x] Bad noisy pruning


### PR DESCRIPTION
```
Elo   | 14.06 +- 8.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.25 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2596 W: 768 L: 663 D: 1165
Penta | [29, 280, 596, 343, 50]
```
https://chess.n9x.co/test/2863/

bench 1688005