### PR TITLE
Alpha-raise reduction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,7 +101,7 @@
 - [ ] Hindsight reductions
 - [ ] Hindsight extensions
 - [x] Razoring
-- [ ] Alpha raise reductions
+- [x] Alpha raise reductions
 - [ ] Probcut
 - [ ] SF small probcut idea
 - [ ] Deeper/shallower

--- a/src/search.rs
+++ b/src/search.rs
@@ -378,6 +378,12 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
                 flag = TTFlag::Lower;
                 break;
             }
+
+            // Alpha-raise reduction
+            if depth > 2 && depth < 12 && !is_mate_score {
+                depth -= 1;
+            }
+
         }
     }
 


### PR DESCRIPTION
```
Elo   | 12.46 +- 7.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.32 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2818 W: 765 L: 664 D: 1389
Penta | [16, 314, 657, 397, 25]
```
https://chess.n9x.co/test/2915/
