### PR TITLE
Post-LMR conthist update

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -127,7 +127,7 @@
 - [ ] Dynamic policy updates
 - [ ] Threats capthist
 - [ ] History factoriser
-- [ ] Post-LMR update conthist
+- [x] Post-LMR update conthist
 - [ ] History depth alpha bonus
 - [ ] History depth beta bonus
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -335,6 +335,15 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
             // Re-search if we reduced depth and score beat alpha
             if score > alpha && new_depth > reduced_depth {
                 score = -alpha_beta(&board, td, new_depth, ply + 1, -alpha - 1, -alpha, !cut_node);
+
+                if is_quiet && (score <= alpha || score >= beta) {
+                    let bonus = if score <= alpha {
+                        -(120 * depth as i16 - 75).min(1200)
+                    } else {
+                        (120 * depth as i16 - 75).min(1200)
+                    };
+                    update_continuation_history(td, ply, &mv, pc, bonus);
+                }
             }
         } else if !pv_node || searched_moves > 1 {
             score = -alpha_beta(&board, td, new_depth, ply + 1, -alpha - 1, -alpha, !cut_node);


### PR DESCRIPTION
```
Elo   | 2.62 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.31 (-2.20, 2.20) [0.00, 5.00]
Games | N: 25376 W: 6590 L: 6399 D: 12387
Penta | [225, 2953, 6124, 3178, 208]
```
https://chess.n9x.co/test/2962/

bench 2554237