### PR TITLE
Hindsight reduction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -98,7 +98,7 @@
 - [x] IIR
 - [x] Cutnode IIR
 - [ ] IIR TT depth condition
-- [ ] Hindsight reductions
+- [x] Hindsight reductions
 - [x] Hindsight extensions
 - [x] Razoring
 - [x] Alpha raise reductions

--- a/src/search.rs
+++ b/src/search.rs
@@ -155,6 +155,18 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         depth += 1;
     }
 
+    // Hindsight reduction
+    if !root_node
+        && !pv_node
+        && !in_check
+        && !singular_search
+        && depth >= 2
+        && td.ss[ply - 1].reduction >= 1
+        && Score::is_defined(td.ss[ply - 1].static_eval)
+        && static_eval + td.ss[ply - 1].static_eval > 80 {
+        depth -= 1;
+    }
+
     if !root_node && !pv_node && !in_check && !singular_search{
 
         // Reverse Futility Pruning


### PR DESCRIPTION
```
Elo   | 4.84 +- 4.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.21 (-2.20, 2.20) [0.00, 5.00]
Games | N: 8612 W: 2270 L: 2150 D: 4192
Penta | [73, 973, 2100, 1081, 79]
```
https://chess.n9x.co/test/2969/

bench 2428204