### PR TITLE
Q-search evasion pruning

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@
 - [ ] PVS SEE quiet history
 - [ ] PVS SEE noisy history
 - [ ] Use LMR depth in more places
-- [ ] Qs evasion pruning
+- [x] Qs evasion pruning
 - [ ] Qs guard recaptures
 
 #### Transposition Table

--- a/src/search.rs
+++ b/src/search.rs
@@ -568,6 +568,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
 
         let pc = board.piece_at(mv.from()).unwrap();
         let captured = board.captured(&mv);
+        let is_quiet = captured.is_none();
         let is_mate_score = Score::is_mate(best_score);
 
         // Futility Pruning
@@ -581,6 +582,11 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         // SEE Pruning
         if !in_check && !see::see(&board, &mv, 0) {
             continue;
+        }
+
+        // Evasion Pruning
+        if in_check && move_count > 1 && is_quiet && !is_mate_score {
+            break;
         }
 
         let mut board = *board;


### PR DESCRIPTION
```
Elo   | 3.54 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.60 (-2.59, 2.59) [0.00, 5.00]
Games | N: 16102 W: 4196 L: 4032 D: 7874
Penta | [111, 1907, 3885, 2003, 145]
```
https://chess.n9x.co/test/3078/

bench 2291367