### PR TITLE
Use Lemire's method for TT indexing

### DIFF
--- a/src/tt.rs
+++ b/src/tt.rs
@@ -103,7 +103,7 @@ impl TranspositionTable {
         let idx = self.idx(hash);
         let entry = &mut self.table[idx];
 
-        let key_part = (hash & 0xFFFF) as u16;
+        let key_part = hash as u16;
         let key_match = key_part == entry.key;
 
         if !best_move.exists() && key_match {
@@ -118,9 +118,9 @@ impl TranspositionTable {
     }
 
     fn idx(&self, hash: u64) -> usize {
-        let key = (hash >> 48) as usize;
-        let mask = self.size - 1;
-        key & mask
+        let key = hash as u128;
+        let len = self.table.len() as u128;
+        ((key * len) >> 64) as usize
     }
 
     pub fn fill(&self) -> usize {


### PR DESCRIPTION
```
Elo   | 14.28 +- 7.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.29 (-2.20, 2.20) [0.00, 5.00]
Games | N: 2288 W: 625 L: 531 D: 1132
Penta | [10, 233, 573, 309, 19]
```
https://chess.n9x.co/test/3145/

bench 2377183