### PR TITLE
TT prefetch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -345,6 +345,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         td.ss[ply].pc = Some(pc);
         td.ss[ply].captured = captured;
         td.keys.push(board.hash);
+        td.tt.prefetch(board.hash);
 
         searched_moves += 1;
         td.nodes += 1;
@@ -612,6 +613,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         td.ss[ply].pc = Some(pc);
         td.ss[ply].captured = captured;
         td.keys.push(board.hash);
+        td.tt.prefetch(board.hash);
 
         move_count += 1;
         td.nodes += 1;

--- a/src/tt.rs
+++ b/src/tt.rs
@@ -169,6 +169,18 @@ impl TranspositionTable {
             .count()
     }
 
+    pub fn prefetch(&self, hash: u64) {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
+            let index = self.idx(hash);
+            let ptr = self.table.as_ptr().add(index);
+            _mm_prefetch::<_MM_HINT_T0>(ptr as *const _);
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = hash;
+    }
+
 }
 
 fn to_tt(score: i32, ply: usize) -> i16 {

--- a/src/types/side.rs
+++ b/src/types/side.rs
@@ -1,4 +1,4 @@
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Not};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum Side {
@@ -20,6 +20,17 @@ impl Side {
         *self as usize + 6
     }
 
+}
+
+impl Not for Side {
+    type Output = Side;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Side::White => Side::Black,
+            Side::Black => Side::White,
+        }
+    }
 }
 
 impl<T, const N: usize> Index<Side> for [T; N] {

--- a/src/types/side.rs
+++ b/src/types/side.rs
@@ -1,4 +1,4 @@
-use std::ops::{Index, IndexMut, Not};
+use std::ops::{Index, IndexMut};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum Side {
@@ -20,17 +20,6 @@ impl Side {
         *self as usize + 6
     }
 
-}
-
-impl Not for Side {
-    type Output = Side;
-
-    fn not(self) -> Self::Output {
-        match self {
-            Side::White => Side::Black,
-            Side::Black => Side::White,
-        }
-    }
 }
 
 impl<T, const N: usize> Index<Side> for [T; N] {


### PR DESCRIPTION
```
Elo   | 9.12 +- 5.99 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.22 (-2.20, 2.20) [0.00, 5.00]
Games | N: 3658 W: 1017 L: 921 D: 1720
Penta | [23, 362, 980, 424, 40]
```
https://chess.n9x.co/test/3233/