### PR TITLE
Use history in FP margin

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -29,6 +29,7 @@ tunable_params! {
     fp_base                     = 150, 50, 250, 25;
     fp_scale                    = 100, 50, 200, 10;
     fp_movecount_mult           = 4, 2, 8, 1;
+    fp_history_divisor          = 137, 64, 256, 16;
     lmp_max_depth               = 8, 6, 10, 1;
     lmp_base                    = 1, 1, 5, 1;
     lmp_improving_base          = 3, 1, 5, 1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -315,7 +315,8 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         // Skip quiet moves when the static evaluation + some margin is still below alpha.
         let futility_margin = fp_base()
             + fp_scale() * lmr_depth
-            - legal_moves * fp_movecount_mult();
+            - legal_moves * fp_movecount_mult()
+            + history_score / fp_history_divisor();
         if !pv_node
             && !root_node
             && !in_check


### PR DESCRIPTION
```
Elo   | 3.61 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 4.00]
Games | N: 16548 W: 4230 L: 4058 D: 8260
Penta | [93, 1948, 4034, 2092, 107]
```
https://chess.n9x.co/test/3403/

bench 2972468