### PR TITLE
Increment NMP base reduction

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -13,7 +13,7 @@ tunable_params! {
     razor_base                  = 303, 200, 500, 25;
     razor_scale                 = 249, 100, 400, 25;
     nmp_min_depth               = 3, 0, 8, 1;
-    nmp_base_reduction          = 3, 2, 5, 1;
+    nmp_base_reduction          = 4, 2, 5, 1;
     nmp_depth_divisor           = 3, 1, 4, 1;
     nmp_eval_divisor            = 168, 100, 300, 25;
     nmp_eval_max_reduction      = 4, 2, 6, 1;


### PR DESCRIPTION
```
Elo   | 4.95 +- 3.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]
Games | N: 10944 W: 2798 L: 2642 D: 5504
Penta | [77, 1243, 2686, 1379, 87]
```
https://chess.n9x.co/test/3463/

bench 2967531