### PR TITLE
Increase FP max depth to 8

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -25,7 +25,7 @@ tunable_params! {
     hindsight_red_min_depth     = 2, 1, 5, 1;
     hindsight_red_min_reduction = 1, 1, 5, 1;
     hindsight_red_eval_diff     = 52, 0, 120, 20;
-    fp_max_depth                = 6, 4, 10, 1;
+    fp_max_depth                = 8, 4, 10, 1;
     fp_base                     = 144, 50, 250, 25;
     fp_scale                    = 105, 50, 200, 10;
     fp_movecount_mult           = 4, 2, 8, 1;


### PR DESCRIPTION
```
Elo   | 4.83 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]
Games | N: 10928 W: 2826 L: 2674 D: 5428
Penta | [56, 1219, 2800, 1295, 94]
```
https://chess.n9x.co/test/3474/

bench 2768462