### PR TITLE
NMP verification search

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@
 - [x] NMP eval-based reduction
 - [x] NMP TT capture
 - [ ] Increment NMP base reduction
-- [ ] NMP verification search
+- [x] NMP verification search
 - [ ] NMP TT condition
 
 #### LMR

--- a/src/search.rs
+++ b/src/search.rs
@@ -243,7 +243,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
         // Skip nodes where giving the opponent an extra move (making a 'null move') still fails high.
         if depth >= nmp_min_depth()
             && static_eval >= beta
-            && ply > td.nmp_min_ply
+            && ply as i32 > td.nmp_min_ply
             && board.has_non_pawns() {
 
             let r = nmp_base_reduction()
@@ -265,7 +265,7 @@ fn alpha_beta(board: &Board, td: &mut ThreadData, mut depth: i32, ply: usize, mu
                 }
 
                 // At high depths, we do a normal search to verify the null move result.
-                td.nmp_min_ply = (3 * (depth - r) / 4) as usize + ply;
+                td.nmp_min_ply = (3 * (depth - r) / 4) + ply as i32;
                 let verif_score = alpha_beta(&board, td, depth - r, ply, beta - 1, beta, true);
                 td.nmp_min_ply = 0;
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -26,7 +26,7 @@ pub struct ThreadData {
     pub nodes: u64,
     pub depth: i32,
     pub seldepth: usize,
-    pub nmp_min_ply: usize,
+    pub nmp_min_ply: i32,
     pub best_move: Move,
     pub best_score: i32,
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -26,6 +26,7 @@ pub struct ThreadData {
     pub nodes: u64,
     pub depth: i32,
     pub seldepth: usize,
+    pub nmp_min_ply: usize,
     pub best_move: Move,
     pub best_score: i32,
 }
@@ -50,6 +51,7 @@ impl Default for ThreadData {
             nodes: 0,
             depth: 0,
             seldepth: 0,
+            nmp_min_ply: 0,
             best_move: Move::NONE,
             best_score: Score::MIN,
         }


### PR DESCRIPTION
Stopping non-reg early, not expecting it to affect strength.

```
Elo   | -0.66 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.63 (-2.23, 2.55) [-5.00, 0.00]
Games | N: 12132 W: 3003 L: 3026 D: 6103
Penta | [63, 1438, 3095, 1399, 71]
```
https://chess.n9x.co/test/3540/