### PR TITLE
Handle negative time sent from UCI

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -234,37 +234,25 @@ impl UCI {
         };
 
         let fischer = if tokens.contains(&String::from("wtime")) {
-            let wtime = match self.parse_uint(&tokens, "wtime") {
-                Ok(wtime) => wtime,
-                Err(_) => {
-                    println!("info error: wtime is not a valid number");
-                    return;
-                }
-            };
+            let wtime = self.parse_uint(&tokens, "wtime").unwrap_or_else(|_| {
+                println!("info error: wtime is not a valid number");
+                500
+            });
 
-            let btime = match self.parse_uint(&tokens, "btime") {
-                Ok(btime) => btime,
-                Err(_) => {
-                    println!("info error: btime is not a valid number");
-                    return;
-                }
-            };
+            let btime = self.parse_uint(&tokens, "btime").unwrap_or_else(|_| {
+                println!("info error: btime is not a valid number");
+                500
+            });
 
-            let winc = match self.parse_uint(&tokens, "winc") {
-                Ok(winc) => winc,
-                Err(_) => {
-                    println!("info error: winc is not a valid number");
-                    return;
-                }
-            };
+            let winc = self.parse_uint(&tokens, "winc").unwrap_or_else(|_| {
+                println!("info error: winc is not a valid number");
+                0
+            });
 
-            let binc = match self.parse_uint(&tokens, "binc") {
-                Ok(binc) => binc,
-                Err(_) => {
-                    println!("info error: binc is not a valid number");
-                    return;
-                }
-            };
+            let binc = self.parse_uint(&tokens, "binc").unwrap_or_else(|_| {
+                println!("info error: binc is not a valid number");
+                0
+            });
 
             let (time, inc) = match self.board.stm {
                 White => (wtime, winc),

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -226,7 +226,7 @@ impl UCI {
                 Ok(movetime) => Some(movetime),
                 Err(_) => {
                     println!("info error: movetime is not a valid number");
-                    return;
+                    Some(500)
                 }
             }
         } else {


### PR DESCRIPTION
Quick non-reg (hopefully this solves the crashes?)

```
Elo   | 2.32 +- 9.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.97 (-2.23, 2.55) [-10.00, 0.00]
Games | N: 1198 W: 304 L: 296 D: 598
Penta | [3, 125, 335, 133, 3]
```
https://chess.n9x.co/test/3574/