### PR TITLE
Random move fallback

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -91,6 +91,13 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
         print_search_info(td);
     }
 
+    // If time expired before a best move was found in search, pick the first legal move.
+    if !td.best_move.exists() {
+        if let Some(root_move) = root_moves.get(0) {
+            td.best_move = root_move.mv;
+        }
+    }
+
     (td.best_move, td.best_score)
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -94,6 +94,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
     // If time expired before a best move was found in search, pick the first legal move.
     if !td.best_move.exists() {
         if let Some(root_move) = root_moves.get(0) {
+            println!("info error no best move was found in search, returning random move");
             td.best_move = root_move.mv;
         }
     }


### PR DESCRIPTION
Passed non-reg:
```
Elo   | 0.85 +- 2.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.67 (-2.23, 2.55) [-5.00, 0.00]
Games | N: 15128 W: 3755 L: 3718 D: 7655
Penta | [62, 1499, 4404, 1538, 61]
```
https://kelseyde.pythonanywhere.com/test/933/