### PR TITLE
+1 billion positions

### DIFF
--- a/network.txt
+++ b/network.txt
@@ -1,1 +1,1 @@
-hobbes-23
+hobbes-24

--- a/network_history.txt
+++ b/network_history.txt
@@ -200,8 +200,23 @@ hobbes-22     | (768x6hm->1024)x2->1 | source: hobbes 6 -> 21      | Elo   | 12.
               | 5, 5, 5, 5,          |                             |                                                |                                                |
               | 5, 5, 5, 5,          |                             |                                                |                                                |
 --------------|----------------------|-----------------------------|------------------------------------------------|------------------------------------------------|
-hobbes-22     | (768x6hm->1024)x2->1 | source: hobbes 6 -> 21      | Elo   | 6.02 +- 4.05 (95%)                     | Elo   | -17.43 +- 7.30 (95%)                   |
+hobbes-23     | (768x6hm->1024)x2->1 | source: hobbes 6 -> 21      | Elo   | 6.02 +- 4.05 (95%)                     | Elo   | -17.43 +- 7.30 (95%)                   |
               | activ: screlu        | dataset: 4.2 billion        | SPRT  | 8.0+0.08s Threads=1 Hash=8MB           | Conf  | 8.0+0.08s Threads=1 Hash=8MB           |
+              | scale: 400           | sb: 800                     | LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]        | Games | N: 3012 W: 745 L: 896 D: 1371          |
+              | quant: [255,64]      | lr: cosine(0.001,0.0000081) | Games | N: 8772 W: 2365 L: 2213 D: 4194        | Penta | [50, 423, 688, 318, 27]                |
+              | optim: AdamW         | wdl: 100sb constant(0.2),   | Penta | [72, 985, 2135, 1107, 87]              | https://kelseyde.pythonanywhere.com/test/1232/ |
+              | buckets:             |      700sb linear(0.2,0.4)  | https://kelseyde.pythonanywhere.com/test/1231/ |                                                |
+              | 0, 0, 1, 1,          | viriformat -> bulletformat  |                                                |                                                |
+              | 2, 2, 3, 3,          |                             |                                                |                                                |
+              | 4, 4, 4, 4,          |                             |                                                |                                                |
+              | 4, 4, 4, 4,          |                             |                                                |                                                |
+              | 4, 4, 4, 4,          |                             |                                                |                                                |
+              | 5, 5, 5, 5,          |                             |                                                |                                                |
+              | 5, 5, 5, 5,          |                             |                                                |                                                |
+              | 5, 5, 5, 5,          |                             |                                                |                                                |
+--------------|----------------------|-----------------------------|------------------------------------------------|------------------------------------------------|
+hobbes-24     | (768x6hm->1024)x2->1 | source: hobbes 6 -> 23      | Elo   | 6.02 +- 4.05 (95%)                     | Elo   | -17.43 +- 7.30 (95%)                   |
+              | activ: screlu        | dataset: 5 billion          | SPRT  | 8.0+0.08s Threads=1 Hash=8MB           | Conf  | 8.0+0.08s Threads=1 Hash=8MB           |
               | scale: 400           | sb: 800                     | LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]        | Games | N: 3012 W: 745 L: 896 D: 1371          |
               | quant: [255,64]      | lr: cosine(0.001,0.0000081) | Games | N: 8772 W: 2365 L: 2213 D: 4194        | Penta | [50, 423, 688, 318, 27]                |
               | optim: AdamW         | wdl: 100sb constant(0.2),   | Penta | [72, 985, 2135, 1107, 87]              | https://kelseyde.pythonanywhere.com/test/1232/ |


### PR DESCRIPTION
```
Elo   | 4.97 +- 3.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.58 (-2.23, 2.55) [0.00, 4.00]
Games | N: 11114 W: 3000 L: 2841 D: 5273
Penta | [79, 1277, 2704, 1400, 97]
```
https://kelseyde.pythonanywhere.com/test/1328/

bench 2745900