### PR TITLE
Allow hp in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -420,7 +420,6 @@ fn alpha_beta(board: &Board,
         // Skip quiet moves that have a bad history score.
         if !pv_node
             && !root_node
-            && !in_check
             && !is_mate_score
             && is_quiet
             && depth <= hp_max_depth()


### PR DESCRIPTION
```
Elo   | 2.76 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.55 (-2.23, 2.55) [0.00, 4.00]
Games | N: 24444 W: 6299 L: 6105 D: 12040
Penta | [153, 2793, 6131, 2997, 148]
```
https://kelseyde.pythonanywhere.com/test/1584/

bench 2394818