### PR TITLE
Reduce minimum LMR depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -521,6 +521,8 @@ fn alpha_beta(board: &Board,
             reduction -= tt_pv as i32 * lmr_pv_node();
             reduction += cut_node as i32 * lmr_cut_node();
             reduction += !improving as i32 * lmr_improving();
+            reduction -= (depth == lmr_min_depth()) as i32 * lmr_shallow();
+
             if is_quiet {
                 reduction -= ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             }

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -54,11 +54,12 @@ tunable_params! {
     se_depth_offset             = 1, 0, 3, 1;
     se_depth_divisor            = 2, 1, 4, 1;
     se_double_ext_margin        = 17, 10, 30, 5;
-    lmr_min_depth               = 3, 1, 5, 1;
+    lmr_min_depth               = 2, 1, 5, 1;
     lmr_min_moves               = 3, 1, 4, 1;
     lmr_pv_node                 = 1124, 0, 2048, 256;
     lmr_cut_node                = 1398, 0, 2048, 256;
     lmr_improving               = 629, 0, 2048, 256;
+    lmr_shallow                 = 1024, 0, 2048, 256;
     lmr_hist_offset             = 387, -2048, 2048, 256;
     lmr_hist_divisor            = 19156, 8192, 32768, 2048;
     lmr_cont_hist_bonus_scale   = 209, 80, 280, 40;


### PR DESCRIPTION
```
Elo   | 3.03 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.74 (-2.23, 2.55) [0.00, 3.00]
Games | N: 26154 W: 6677 L: 6449 D: 13028
Penta | [138, 2984, 6627, 3168, 160]
```
https://kelseyde.pythonanywhere.com/test/1619/

bench 2306822