### PR TITLE
Fail firm in q-search beta cutoff

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -867,6 +867,10 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         return -Score::MATE + ply as i32;
     }
 
+    if best_score >= beta && Score::is_defined(best_score) {
+        best_score = (best_score + beta) / 2;
+    }
+
     // Write to transposition table
     if !td.hard_limit_reached() {
         td.tt.insert(board.hash(), best_move, best_score, 0, ply, flag, tt_pv);


### PR DESCRIPTION
```
Elo   | 1.50 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 3.00]
Games | N: 77630 W: 19578 L: 19243 D: 38809
Penta | [427, 8986, 19651, 9327, 424]
```
https://kelseyde.pythonanywhere.com/test/1629/

bench 2440040