### PR TITLE
Reduce less during LMR when extending

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -529,6 +529,7 @@ fn alpha_beta(board: &Board,
             reduction += cut_node as i32 * lmr_cut_node();
             reduction += !improving as i32 * lmr_improving();
             reduction -= (depth == lmr_min_depth()) as i32 * lmr_shallow();
+            reduction -= extension * 1024 / 3;
 
             if is_quiet {
                 reduction -= ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;


### PR DESCRIPTION
```
Elo   | 1.27 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.58 (-2.23, 2.55) [0.00, 3.00]
Games | N: 109590 W: 27578 L: 27177 D: 54835
Penta | [545, 12339, 28684, 12624, 603]
```
https://kelseyde.pythonanywhere.com/test/1672/

bench 2199523
