### PR TITLE
LMR for captures

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -515,8 +515,7 @@ fn alpha_beta(board: &Board,
         // We assume that the first move will be best, and search all others with a null window and/or
         // reduced depth. If any of those moves beat alpha, we re-search with a full window and depth.
         if depth >= lmr_min_depth()
-            && searched_moves > lmr_min_moves() + root_node as i32 + pv_node as i32
-            && is_quiet {
+            && searched_moves > lmr_min_moves() + root_node as i32 + pv_node as i32 {
 
             // Late Move Reductions
             // Moves ordered late in the list are less likely to be good, so we reduce the depth.

--- a/src/search.rs
+++ b/src/search.rs
@@ -523,9 +523,9 @@ fn alpha_beta(board: &Board,
             r -= lmr_ttpv_tt_score() * (tt_pv && has_tt_score && tt_score > alpha) as i32;
             r -= lmr_ttpv_tt_depth() * (tt_pv && has_tt_score && tt_depth >= depth) as i32;
             r += lmr_cut_node() * cut_node as i32;
+            r -= lmr_capture() * captured.is_some() as i32;
             r += lmr_improving() * !improving as i32;
             r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
-            r -= 1024 * captured.is_some() as i32;
             r -= extension * 1024 / 3;
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c) / lmr_mvv_divisor());

--- a/src/search.rs
+++ b/src/search.rs
@@ -514,27 +514,25 @@ fn alpha_beta(board: &Board,
         // Principal Variation Search
         // We assume that the first move will be best, and search all others with a null window and/or
         // reduced depth. If any of those moves beat alpha, we re-search with a full window and depth.
-        if depth >= lmr_min_depth()
-            && searched_moves > lmr_min_moves() + root_node as i32 + pv_node as i32 {
+        if depth >= lmr_min_depth() && searched_moves > lmr_min_moves() + root_node as i32 + pv_node as i32 {
 
             // Late Move Reductions
             // Moves ordered late in the list are less likely to be good, so we reduce the depth.
-            let mut reduction = base_reduction * 1024;
-
-            reduction -= lmr_ttpv_base() * (is_quiet && tt_pv) as i32;
-            reduction -= lmr_ttpv_tt_score() * (is_quiet && tt_pv && has_tt_score && tt_score > alpha) as i32;
-            reduction -= lmr_ttpv_tt_depth() * (is_quiet && tt_pv && has_tt_score && tt_depth >= depth) as i32;
-            reduction += lmr_cut_node() * (is_quiet && cut_node) as i32;
-            reduction += lmr_improving() * (is_quiet && !improving) as i32;
-            reduction -= lmr_shallow() * (is_quiet && depth == lmr_min_depth()) as i32;
-            reduction -= is_quiet as i32 * extension * 1024 / 3;
-            reduction -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
-            //reduction -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c) / lmr_mvv_divisor());
-
-            let reduced_depth = (new_depth - (reduction / 1024)).clamp(1, new_depth);
+            let mut r = base_reduction * 1024;
+            r -= lmr_ttpv_base() * tt_pv as i32;
+            r -= lmr_ttpv_tt_score() * (tt_pv && has_tt_score && tt_score > alpha) as i32;
+            r -= lmr_ttpv_tt_depth() * (tt_pv && has_tt_score && tt_depth >= depth) as i32;
+            r += lmr_cut_node() * cut_node as i32;
+            r += lmr_improving() * !improving as i32;
+            r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
+            r -= 1024 * captured.is_some() as i32;
+            r -= extension * 1024 / 3;
+            r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
+            r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c) / lmr_mvv_divisor());
+            let reduced_depth = (new_depth - (r / 1024)).clamp(1, new_depth);
 
             // For moves eligible for reduction, we apply the reduction and search with a null window.
-            td.ss[ply].reduction = reduction;
+            td.ss[ply].reduction = r;
             score = -alpha_beta(&board, td, reduced_depth, ply + 1, -alpha - 1, -alpha, true);
             td.ss[ply].reduction = 0;
 

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -60,6 +60,7 @@ tunable_params! {
     lmr_ttpv_tt_score           = 700, 0, 2048, 256;
     lmr_ttpv_tt_depth           = 700, 0, 2048, 256;
     lmr_cut_node                = 1398, 0, 2048, 256;
+    lmr_capture                 = 1024, 0, 2048, 256;
     lmr_improving               = 629, 0, 2048, 256;
     lmr_shallow                 = 1024, 0, 2048, 256;
     lmr_hist_offset             = 387, -2048, 2048, 256;


### PR DESCRIPTION
Merging this early as a non-reg. Having LMR term for captures will make it easier to tune later. 

```
Elo   | 0.27 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -1.32 (-2.23, 2.55) [0.00, 3.00]
Games | N: 53278 W: 13311 L: 13270 D: 26697
Penta | [292, 6247, 13504, 6320, 276]
https://kelseyde.pythonanywhere.com/test/1678/
```
bench 2308113