### PR TITLE
Support DFRC datagen

### DIFF
--- a/src/tools/datagen.rs
+++ b/src/tools/datagen.rs
@@ -7,13 +7,14 @@ use rand::{Rng, SeedableRng};
 pub fn generate_random_openings(td: &mut ThreadData,
                                 count: usize,
                                 seed: u64,
-                                random_moves: usize) -> Vec<String> {
+                                random_moves: usize,
+                                dfrc: bool) -> Vec<String> {
 
 
     let mut rng = StdRng::seed_from_u64(seed);
 
     let openings = (0..count)
-        .map(|_| generate_random_opening(td, &mut rng, random_moves))
+        .map(|_| generate_random_opening(td, &mut rng, random_moves, dfrc))
         .collect::<Vec<String>>();
 
     openings
@@ -21,9 +22,10 @@ pub fn generate_random_openings(td: &mut ThreadData,
 
 fn generate_random_opening(td: &mut ThreadData,
                            rng: &mut StdRng,
-                           random_moves: usize) -> String {
+                           random_moves: usize,
+                           dfrc: bool) -> String {
 
-    let mut board = Board::from_fen(fen::STARTPOS).unwrap();
+    let mut board = startpos(rng, dfrc);
 
     // ensure an equal distribution of white stm and black stm exits
     let random_moves = if rng.random_bool(0.5) { random_moves } else { random_moves + 1 };
@@ -33,7 +35,7 @@ fn generate_random_opening(td: &mut ThreadData,
 
         // If we reached a terminal position, retry recursively
         if legal_moves.is_empty() {
-            return generate_random_opening(td, rng, random_moves);
+            return generate_random_opening(td, rng, random_moves, dfrc);
         }
 
         let mv = legal_moves.get(rng.random_range(0..legal_moves.len())).unwrap();
@@ -43,16 +45,25 @@ fn generate_random_opening(td: &mut ThreadData,
     // Skip wildly imbalanced exits
     td.nnue.activate(&board);
     if td.nnue.evaluate(&board).abs() > 1000 {
-        return generate_random_opening(td, rng, random_moves);
+        return generate_random_opening(td, rng, random_moves, dfrc);
     }
 
     let legal_moves = board.gen_legal_moves();
     // If we reached a terminal position, retry recursively
     if legal_moves.is_empty() {
-        return generate_random_opening(td, rng, random_moves);
+        return generate_random_opening(td, rng, random_moves, dfrc);
     }
 
     board.to_fen()
+}
+
+fn startpos(rng: &mut StdRng, dfrc: bool) -> Board {
+    if !dfrc {
+        Board::from_fen(fen::STARTPOS).unwrap()
+    } else {
+        let dfrc_seed = rng.random_range(0..960 * 960);
+        Board::from_dfrc_idx(dfrc_seed)
+    }
 }
 
 

--- a/src/tools/fen.rs
+++ b/src/tools/fen.rs
@@ -134,22 +134,7 @@ impl Board {
         fen.push(if self.stm == White { 'w' } else { 'b' });
 
         fen.push(' ');
-        if self.rights.is_empty() {
-            fen.push('-');
-        } else {
-            if self.rights.kingside(White).is_some() {
-                fen.push('K');
-            }
-            if self.rights.queenside(White).is_some() {
-                fen.push('Q');
-            }
-            if self.rights.kingside(Black).is_some() {
-                fen.push('k');
-            }
-            if self.rights.queenside(Black).is_some() {
-                fen.push('q');
-            }
-        }
+        fen.push_str(self.rights.to_string(self.frc).as_str());
 
         fen.push(' ');
         if let Some(ep_sq) = self.ep_sq {
@@ -397,6 +382,7 @@ mod tests {
         assert_eq!(Some(File::A), board1.rights.queenside(White));
         assert_eq!(Some(File::H), board1.rights.kingside(Black));
         assert_eq!(Some(File::A), board1.rights.queenside(Black));
+        assert_eq!("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w HAha - 0 1", board1.to_fen());
 
         let board2 =
             Board::from_fen("bnnrkbqr/pppppppp/8/8/8/8/PPPPPPPP/BNNRKBQR w HDhd -").unwrap();
@@ -408,6 +394,7 @@ mod tests {
         assert_eq!(Some(File::D), board2.rights.queenside(White));
         assert_eq!(Some(File::H), board2.rights.kingside(Black));
         assert_eq!(Some(File::D), board2.rights.queenside(Black));
+        assert_eq!("bnnrkbqr/pppppppp/8/8/8/8/PPPPPPPP/BNNRKBQR w HDhd - 0 0", board2.to_fen());
 
         let board3 =
             Board::from_fen("nrkqbrnb/pppppppp/8/8/8/8/PPPPPPPP/NRKQBRNB w FBfb -").unwrap();
@@ -419,6 +406,7 @@ mod tests {
         assert_eq!(Some(File::B), board3.rights.queenside(White));
         assert_eq!(Some(File::F), board3.rights.kingside(Black));
         assert_eq!(Some(File::B), board3.rights.queenside(Black));
+        assert_eq!("nrkqbrnb/pppppppp/8/8/8/8/PPPPPPPP/NRKQBRNB w FBfb - 0 0", board3.to_fen());
 
     }
 }

--- a/src/tools/uci.rs
+++ b/src/tools/uci.rs
@@ -394,7 +394,8 @@ impl UCI {
             8
         }) as usize;
 
-        for opening in generate_random_openings(&mut self.td, count, seed, random_moves) {
+        let dfrc = self.board.frc;
+        for opening in generate_random_openings(&mut self.td, count, seed, random_moves, dfrc) {
             println!("info string genfens {}", opening);
         }
 


### PR DESCRIPTION
```
Elo   | 5.40 +- 7.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.23, 2.55) [-10.00, 0.00]
Games | N: 2318 W: 586 L: 550 D: 1182
Penta | [11, 243, 615, 279, 11]
```
https://kelseyde.pythonanywhere.com/test/1704/

bench 2308419