### PR TITLE
Reduce killers less

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -529,7 +529,7 @@ fn alpha_beta(board: &Board,
             r -= lmr_capture() * captured.is_some() as i32;
             r += lmr_improving() * !improving as i32;
             r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
-            r -= td.ss[ply].killer.is_some_and(|k| k == mv) as i32 * 1024;
+            r -= td.ss[ply].killer.is_some_and(|k| k == mv) as i32 * lmr_killer();
             r -= extension * 1024 / lmr_extension_divisor();
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c) / lmr_mvv_divisor());

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -64,6 +64,7 @@ tunable_params! {
     lmr_capture                 = 1410, 0, 2048, 256;
     lmr_improving               = 639, 0, 2048, 256;
     lmr_shallow                 = 968, 0, 2048, 256;
+    lmr_killer                  = 1024, 0, 2048, 256;
     lmr_hist_offset             = 227, -2048, 2048, 256;
     lmr_hist_divisor            = 20952, 8192, 32768, 2048;
     lmr_mvv_divisor             = 3, 1, 5, 1;


### PR DESCRIPTION
```
Elo   | 8.99 +- 4.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.64 (-2.23, 2.55) [0.00, 4.00]
Games | N: 5298 W: 1432 L: 1295 D: 2571
Penta | [22, 567, 1350, 672, 38]
```
https://chess.n9x.co/test/4287/
bench 2809887