### PR TITLE
LMR deeper/shallower

### DIFF
--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -69,6 +69,9 @@ tunable_params! {
     lmr_hist_divisor            = 20952, 8192, 32768, 2048;
     lmr_mvv_divisor             = 3, 1, 5, 1;
     lmr_extension_divisor       = 4, 1, 6, 1;
+    lmr_deeper_base             = 40, 0, 100, 10;
+    lmr_deeper_scale            = 500, 350, 600, 50;
+    lmr_deeper_div              = 128, 64, 256, 16;
     lmr_cont_hist_bonus_scale   = 201, 80, 280, 40;
     lmr_cont_hist_bonus_offset  = 123, 0, 200, 25;
     lmr_cont_hist_bonus_max     = 1080, 1000, 1600, 100;


### PR DESCRIPTION
```
Elo   | 4.50 +- 3.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.67 (-2.23, 2.55) [0.00, 4.00]
Games | N: 12290 W: 3233 L: 3074 D: 5983
Penta | [49, 1400, 3113, 1509, 74]
```
https://chess.n9x.co/test/4316/

bench 2802706