### PR TITLE
Add NMP eval margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -301,7 +301,7 @@ fn alpha_beta(board: &Board,
         // Null Move Pruning
         // Skip nodes where giving the opponent an extra move (making a 'null move') still fails high.
         if depth >= nmp_min_depth()
-            && static_eval >= beta + 30
+            && static_eval >= beta + nmp_margin()
             && ply as i32 > td.nmp_min_ply
             && board.has_non_pawns() {
 

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -14,6 +14,7 @@ tunable_params! {
     razor_base                  = 301, 200, 500, 25;
     razor_scale                 = 273, 100, 400, 25;
     nmp_min_depth               = 3, 0, 8, 1;
+    nmp_margin                  = 30, 0, 80, 10;
     nmp_base_reduction          = 4, 2, 5, 1;
     nmp_depth_divisor           = 3, 1, 4, 1;
     nmp_eval_divisor            = 213, 100, 300, 25;


### PR DESCRIPTION
```
Elo   | 13.05 +- 6.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]
Games | N: 3436 W: 953 L: 824 D: 1659
Penta | [15, 350, 872, 453, 28]
```
https://chess.n9x.co/test/4331/