### PR TITLE
Do LMR earlier in non-PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -517,7 +517,7 @@ fn alpha_beta(board: &Board,
         // Principal Variation Search
         // We assume that the first move will be best, and search all others with a null window and/or
         // reduced depth. If any of those moves beat alpha, we re-search with a full window and depth.
-        if depth >= lmr_min_depth() && searched_moves > lmr_min_moves() + root_node as i32 + pv_node as i32 {
+        if depth >= lmr_min_depth() && searched_moves > lmr_min_moves() + root_node as i32 + 2 * pv_node as i32 {
 
             // Late Move Reductions
             // Moves ordered late in the list are less likely to be good, so we reduce the depth.

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -57,7 +57,7 @@ tunable_params! {
     se_depth_divisor            = 2, 1, 4, 1;
     se_double_ext_margin        = 12, 10, 30, 5;
     lmr_min_depth               = 2, 1, 5, 1;
-    lmr_min_moves               = 3, 1, 4, 1;
+    lmr_min_moves               = 2, 1, 4, 1;
     lmr_ttpv_base               = 567, 0, 2048, 256;
     lmr_ttpv_tt_score           = 785, 0, 2048, 256;
     lmr_ttpv_tt_depth           = 944, 0, 2048, 256;


### PR DESCRIPTION
```
Elo   | 2.10 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.56 (-2.23, 2.55) [0.00, 4.00]
Games | N: 37180 W: 9509 L: 9284 D: 18387
Penta | [148, 4215, 9672, 4374, 181]
```
https://chess.n9x.co/test/4357/

bench 2907643