### PR TITLE
Prune all bad noisies in q-search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -20,6 +20,7 @@ use crate::search::tt::TTFlag;
 use arrayvec::ArrayVec;
 use parameters::*;
 use std::ops::{Index, IndexMut};
+use crate::search::movepicker::Stage::BadNoisies;
 
 pub const MAX_PLY: usize = 256;
 
@@ -806,6 +807,10 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
 
         if !board.is_legal(&mv) {
             continue;
+        }
+
+        if move_picker.stage == BadNoisies {
+            break;
         }
 
         let pc = board.piece_at(mv.from()).unwrap();


### PR DESCRIPTION
```
Elo   | 1.92 +- 3.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.56 (-2.23, 2.55) [-4.00, 0.00]
Games | N: 13422 W: 3384 L: 3310 D: 6728
Penta | [49, 1511, 3527, 1565, 59]
```
https://chess.n9x.co/test/4376/

bench 2842279