### PR TITLE
Detect rook file in FEN parsing for DFRC compatibility

### DIFF
--- a/src/tools/fen.rs
+++ b/src/tools/fen.rs
@@ -165,10 +165,18 @@ fn parse_castle_rights(board: &Board, castle: &str) -> (Rights, bool) {
     for c in castle.chars() {
         match c {
             // Standard FEN notation
-            'K' => rights.set_kingside(White, File::H),
-            'Q' => rights.set_queenside(White, File::A),
-            'k' => rights.set_kingside(Black, File::H),
-            'q' => rights.set_queenside(Black, File::A),
+            'K' => if let Some(file) = find_rook_file(board, White, true){
+                rights.set_kingside(White, file)
+            },
+            'Q' => if let Some(file) = find_rook_file(board, White, false) {
+                rights.set_queenside(White, file)
+            }
+            'k' => if let Some(file) = find_rook_file(board, Black, true) {
+                rights.set_kingside(Black, file)
+            }
+            'q' => if let Some(file) = find_rook_file(board, Black, false) {
+                rights.set_queenside(Black, file)
+            }
             '-' => (),
 
             // Shredder FEN notation
@@ -252,6 +260,23 @@ fn piece_to_char(piece: Piece, side: Side) -> char {
     } else {
         ch
     }
+}
+
+fn find_rook_file(board: &Board, side: Side, kingside: bool) -> Option<File> {
+    let king_sq = board.king_sq(side);
+    let rooks = board.rooks(side);
+    let candidate_files = if kingside {
+        [File::H, File::G, File::F, File::E, File::D, File::C]
+    } else {
+        [File::A, File::B, File::C, File::D, File::E, File::F]
+    };
+    for &file in &candidate_files {
+        let sq = Square::from(file, king_sq.rank());
+        if rooks.contains(sq) {
+            return Some(file);
+        }
+    }
+    None
 }
 
 


### PR DESCRIPTION
Non-reg standard:
```
Elo   | -0.00 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.60 (-2.23, 2.55) [-10.00, 0.00]
Games | N: 6280 W: 1564 L: 1564 D: 3152
Penta | [33, 663, 1737, 685, 22]
```
https://chess.n9x.co/test/4387/

Non-reg DFRC:
```
Elo   | -0.82 +- 4.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.73 (-2.23, 2.55) [-10.00, 0.00]
Games | N: 9282 W: 2027 L: 2049 D: 5206
Penta | [117, 1033, 2357, 1023, 111]
```
https://chess.n9x.co/test/4388/


bench 2842279