### PR TITLE
Add fifty-move-rule scaling

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -335,7 +335,9 @@ fn should_mirror(king_sq: Square) -> bool {
 
 fn scale_evaluation(board: &Board, eval: i32) -> i32 {
     let phase = material_phase(board);
-    eval * (material_scaling_base() + phase) / 32768
+    eval
+        * (material_scaling_base() + phase) / 32768
+        * (200 - board.hm as i32) / 200
 }
 
 fn material_phase(board: &Board) -> i32 {


### PR DESCRIPTION
```
Elo   | 1.93 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.62 (-2.23, 2.55) [0.00, 4.00]
Games | N: 25382 W: 4964 L: 4823 D: 15595
Penta | [7, 1710, 9118, 1847, 9]
```
https://chess.n9x.co/test/4407/

bench 3086218