### PR TITLE
Fused finny table refreshes

### DIFF
--- a/src/evaluation/accumulator.rs
+++ b/src/evaluation/accumulator.rs
@@ -204,4 +204,70 @@ impl Accumulator {
             i += 1;
         }
     }
+
+    #[inline]
+    pub fn add_add_add_add(
+        &mut self,
+        add1: Feature,
+        add2: Feature,
+        add3: Feature,
+        add4: Feature,
+        weights: &FeatureWeights,
+        perspective: Side
+    ) {
+        let mirror = self.mirrored[perspective as usize];
+
+        let add1_offset = add1.index(perspective, mirror) * HIDDEN;
+        let add2_offset = add2.index(perspective, mirror) * HIDDEN;
+        let add3_offset = add3.index(perspective, mirror) * HIDDEN;
+        let add4_offset = add4.index(perspective, mirror) * HIDDEN;
+
+        let feats = self.features_mut(perspective);
+
+        let mut i = 0;
+        while i < HIDDEN {
+            unsafe {
+                let feat_ptr = feats.get_unchecked_mut(i);
+                *feat_ptr = feat_ptr
+                    .wrapping_add(*weights.get_unchecked(i + add1_offset))
+                    .wrapping_add(*weights.get_unchecked(i + add2_offset))
+                    .wrapping_add(*weights.get_unchecked(i + add3_offset))
+                    .wrapping_add(*weights.get_unchecked(i + add4_offset));
+            }
+            i += 1;
+        }
+    }
+
+    pub fn sub_sub_sub_sub(
+        &mut self,
+        sub1: Feature,
+        sub2: Feature,
+        sub3: Feature,
+        sub4: Feature,
+        weights: &FeatureWeights,
+        perspective: Side
+    ) {
+        let mirror = self.mirrored[perspective as usize];
+
+        let sub1_offset = sub1.index(perspective, mirror) * HIDDEN;
+        let sub2_offset = sub2.index(perspective, mirror) * HIDDEN;
+        let sub3_offset = sub3.index(perspective, mirror) * HIDDEN;
+        let sub4_offset = sub4.index(perspective, mirror) * HIDDEN;
+
+        let feats = self.features_mut(perspective);
+
+        let mut i = 0;
+        while i < HIDDEN {
+            unsafe {
+                let feat_ptr = feats.get_unchecked_mut(i);
+                *feat_ptr = feat_ptr
+                    .wrapping_sub(*weights.get_unchecked(i + sub1_offset))
+                    .wrapping_sub(*weights.get_unchecked(i + sub2_offset))
+                    .wrapping_sub(*weights.get_unchecked(i + sub3_offset))
+                    .wrapping_sub(*weights.get_unchecked(i + sub4_offset));
+            }
+            i += 1;
+        }
+    }
+
 }

--- a/src/evaluation/feature.rs
+++ b/src/evaluation/feature.rs
@@ -7,6 +7,7 @@ use crate::board::square::Square;
 /// board, with a colour (white or black). The feature can either be activated - meaning the piece
 /// is present on that square - or not  activated - meaning the piece is not present on that square.
 /// The presence or absence of a feature is represented by a 1 or 0 respectively in the input layer.
+#[derive(Copy, Clone)]
 pub struct Feature {
     pc: Piece,
     sq: Square,


### PR DESCRIPTION
```
Elo   | -0.30 +- 2.01 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 2.68 (-2.23, 2.55) [-5.00, 0.00]
Games | N: 33392 W: 8711 L: 8740 D: 15941
Penta | [262, 3820, 8563, 3787, 264]
```
https://chess.n9x.co/test/4446/

bench 3086218