### PR TITLE
Aspiration window fail high reductions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -45,6 +45,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
     let mut beta = Score::MAX;
     let mut score = 0;
     let mut delta = asp_delta();
+    let mut reduction = 0;
 
     // Iterative Deepening
     // Search the position to a fixed depth, increasing the depth each iteration until the maximum
@@ -61,7 +62,8 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
         }
 
         loop {
-            score = alpha_beta(board, td, td.depth, 0, alpha, beta, false);
+            let search_depth = td.depth - reduction;
+            score = alpha_beta(board, td, search_depth, 0, alpha, beta, false);
 
             if td.main && !td.minimal_output {
                 print_search_info(td);
@@ -77,10 +79,12 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
                     beta = (alpha + beta) / 2;
                     alpha = (score - delta).max(Score::MIN);
                     delta += (delta * 100) / asp_alpha_widening_factor();
+                    reduction = 0;
                 }
                 s if s >= beta => {
                     beta = (score + delta).min(Score::MAX);
                     delta += (delta * 100) / asp_beta_widening_factor();
+                    reduction = (reduction + 1).min(3);
                 }
                 _ => break,
             }
@@ -91,6 +95,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
         }
 
         delta = asp_delta();
+        reduction = 0;
         td.depth += 1;
     }
 


### PR DESCRIPTION
```
Elo   | 5.51 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.67 (-2.23, 2.55) [0.00, 4.00]
Games | N: 9206 W: 2414 L: 2268 D: 4524
Penta | [30, 1007, 2393, 1133, 40]
```
https://chess.n9x.co/test/4457/

bench 2107064