### PR TITLE
Reduce more for quiet moves that lose material

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -539,7 +539,7 @@ fn alpha_beta(board: &Board,
             r -= extension * 1024 / lmr_extension_divisor();
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c) / lmr_mvv_divisor());
-            r += (is_quiet && !see::see(&original_board, &mv, 0)) as i32 * 1024;
+            r += (is_quiet && !see::see(&original_board, &mv, 0)) as i32 * lmr_quiet_see();
             let reduced_depth = (new_depth - (r / 1024)).clamp(1, new_depth);
 
             // For moves eligible for reduction, we apply the reduction and search with a null window.

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -66,6 +66,7 @@ tunable_params! {
     lmr_improving               = 639, 0, 2048, 256;
     lmr_shallow                 = 968, 0, 2048, 256;
     lmr_killer                  = 1024, 0, 2048, 256;
+    lmr_quiet_see               = 1024, 0, 2048, 256;
     lmr_hist_offset             = 227, -2048, 2048, 256;
     lmr_hist_divisor            = 20952, 8192, 32768, 2048;
     lmr_mvv_divisor             = 3, 1, 5, 1;


### PR DESCRIPTION
```
Elo   | 5.07 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.63 (-2.23, 2.55) [0.00, 4.00]
Games | N: 10082 W: 2668 L: 2521 D: 4893
Penta | [43, 1080, 2651, 1221, 46]
```
https://chess.n9x.co/test/4496/