### PR TITLE
Use previous score to adjust aspiration delta

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -94,7 +94,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
             break;
         }
 
-        delta = asp_delta();
+        delta = asp_delta() + score * score / asp_prev_score_div();
         reduction = 0;
         td.depth += 1;
     }

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -2,10 +2,11 @@ use crate::tunable_params;
 
 #[rustfmt::skip]
 tunable_params! {
-    asp_delta                   = 10, 4, 36, 4;
+    asp_delta                   = 5, 4, 36, 4;
     asp_min_depth               = 4, 0, 8, 1;
     asp_alpha_widening_factor   = 177, 50, 400, 50;
     asp_beta_widening_factor    = 245, 50, 400, 50;
+    asp_prev_score_div          = 9534, 8000, 11000, 500;
     rfp_max_depth               = 8, 6, 12, 1;
     rfp_base                    = 14, -50, 50, 10;
     rfp_scale                   = 47, 40, 100, 10;


### PR DESCRIPTION
```
Elo   | 1.67 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.60 (-2.23, 2.55) [0.00, 4.00]
Games | N: 67280 W: 17656 L: 17333 D: 32291
Penta | [373, 7679, 17218, 7992, 378]
```
https://chess.n9x.co/test/4634/

bench 1953579