### PR TITLE
Skip RFP if tt bound indicates fail low

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -293,7 +293,9 @@ fn alpha_beta(board: &Board,
             + rfp_scale() * depth
             - rfp_improving_scale() * improving as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
-        if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
+        if depth <= rfp_max_depth()
+            && static_eval - futility_margin >= beta
+            && tt_flag != TTFlag::Upper {
             return beta + (static_eval - beta) / 3;
         }
 


### PR DESCRIPTION
```
Elo   | 5.03 +- 3.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.59 (-2.23, 2.55) [0.00, 4.00]
Games | N: 10434 W: 2820 L: 2669 D: 4945
Penta | [57, 1152, 2655, 1289, 64]
```
https://chess.n9x.co/test/4651/

bench 2068855