### PR TITLE
Skip NMP if tt bound indicates fail low

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -22,6 +22,7 @@ use crate::search::time::LimitType::{Hard, Soft};
 use crate::search::tt::TTFlag;
 use arrayvec::ArrayVec;
 use parameters::*;
+use crate::search::tt::TTFlag::Upper;
 
 pub const MAX_PLY: usize = 256;
 
@@ -295,7 +296,7 @@ fn alpha_beta(board: &Board,
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
         if depth <= rfp_max_depth()
             && static_eval - futility_margin >= beta
-            && tt_flag != TTFlag::Upper {
+            && tt_flag != Upper {
             return beta + (static_eval - beta) / 3;
         }
 
@@ -310,7 +311,8 @@ fn alpha_beta(board: &Board,
         if depth >= nmp_min_depth()
             && static_eval >= beta + nmp_margin()
             && ply as i32 > td.nmp_min_ply
-            && board.has_non_pawns() {
+            && board.has_non_pawns()
+            && tt_flag != Upper {
 
             let r = nmp_base_reduction()
                 + depth / nmp_depth_divisor()


### PR DESCRIPTION
```
Elo   | 4.54 +- 3.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 4.00]
Games | N: 11396 W: 3062 L: 2913 D: 5421
Penta | [46, 1243, 2990, 1354, 65]
```
https://chess.n9x.co/test/4654/
bench 1878694