### PR TITLE
Give extra history bonus in cutnodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -649,13 +649,13 @@ fn alpha_beta(board: &Board,
     if best_move.exists() {
         let pc = board.piece_at(best_move.from()).unwrap();
 
-        let quiet_bonus = quiet_history_bonus(depth);
+        let quiet_bonus = quiet_history_bonus(depth) - quiet_hist_cutnode_offset() as i16 * cut_node as i16;
         let quiet_malus = quiet_history_malus(depth);
 
         let capt_bonus = capture_history_bonus(depth);
         let capt_malus = capture_history_malus(depth);
 
-        let cont_bonus = cont_history_bonus(depth);
+        let cont_bonus = cont_history_bonus(depth) - cont_hist_cutnode_offset() as i16 * cut_node as i16;
         let cont_malus = cont_history_malus(depth);
 
         if let Some(captured) = board.captured(&best_move) {

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -85,6 +85,7 @@ tunable_params! {
     alpha_raise_max_depth       = 12, 8, 16, 1;
     quiet_hist_bonus_scale      = 238, 80, 280, 40;
     quiet_hist_bonus_offset     = 62, 0, 200, 25;
+    quiet_hist_cutnode_offset   = 64, 0, 200, 25;
     quiet_hist_bonus_max        = 1050, 1000, 1600, 100;
     quiet_hist_malus_scale      = 84, 80, 280, 40;
     quiet_hist_malus_offset     = 28, 0, 200, 25;
@@ -97,6 +98,7 @@ tunable_params! {
     capt_hist_malus_max         = 1231, 1000, 1600, 100;
     cont_hist_bonus_scale       = 83, 80, 280, 40;
     cont_hist_bonus_offset      = 200, 0, 200, 25;
+    cont_hist_cutnode_offset    = 64, 0, 200, 25;
     cont_hist_bonus_max         = 1041, 1000, 1600, 100;
     cont_hist_malus_scale       = 80, 80, 280, 40;
     cont_hist_malus_offset      = 79, 0, 200, 25;


### PR DESCRIPTION
```
Elo   | 2.08 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.67 (-2.23, 2.55) [0.00, 4.00]
Games | N: 41430 W: 10979 L: 10731 D: 19720
Penta | [224, 4709, 10624, 4911, 247]
```
https://chess.n9x.co/test/4659/

bench 2140363