### PR TITLE
Increase SE beta window if TT was a PV node

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -481,7 +481,8 @@ fn alpha_beta(board: &Board,
             && tt_flag != TTFlag::Upper
             && tt_depth >= depth - se_tt_depth_offset() {
 
-            let s_beta = (tt_score - depth * se_beta_scale() / 16).max(-Score::MATE + 1);
+            let s_beta_mult = depth * (1 + (tt_pv && !pv_node) as i32);
+            let s_beta = (tt_score - s_beta_mult * se_beta_scale() / 16).max(-Score::MATE + 1);
             let s_depth = (depth - se_depth_offset()) / se_depth_divisor();
 
             td.ss[ply].singular = Some(mv);


### PR DESCRIPTION
Passed STC: 
```
Elo   | 5.28 +- 3.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.59 (-2.23, 2.55) [0.00, 4.00]
Games | N: 9606 W: 2578 L: 2432 D: 4596
Penta | [39, 1058, 2482, 1166, 58]
```
https://chess.n9x.co/test/4670/

Passed LTC:
```
Elo   | 3.90 +- 2.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 4.00]
Games | N: 12472 W: 3246 L: 3106 D: 6120
Penta | [13, 1282, 3510, 1414, 17]
```
https://chess.n9x.co/test/4671/

bench 1895582