### PR TITLE
Q-search late move pruning

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -36,6 +36,7 @@ pub struct Board {
     pub hm: u8,            // number of half moves since last capture or pawn move
     pub fm: u8,            // number of full moves
     pub ep_sq: Option<Square>, // en passant square (0-63)
+    pub recapture_sq: Option<Square>, // square where a recapture can occur
     pub rights: Rights,    // encoded castle rights
     pub keys: Keys,        // zobrist hashes
     pub frc: bool,         // whether the game is Fischer Random Chess
@@ -63,6 +64,7 @@ impl Board {
             hm: 0,
             fm: 0,
             ep_sq: None,
+            recapture_sq: None,
             rights: Rights::default(),
             keys: Keys::default(),
             frc: false,
@@ -107,6 +109,11 @@ impl Board {
         }
 
         self.ep_sq = self.calc_ep(flag, to);
+        self.recapture_sq = if captured.is_some() {
+            Some(m.to())
+        } else {
+            None
+        };
         self.rights = self.calc_castle_rights(from, to, pc);
         self.fm += if side == Black { 1 } else { 0 };
         self.hm = if captured.is_some() || pc == Piece::Pawn {

--- a/src/search.rs
+++ b/src/search.rs
@@ -839,10 +839,11 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         let pc = board.piece_at(mv.from()).unwrap();
         let captured = board.captured(&mv);
         let is_quiet = captured.is_none();
+        let is_recapture = board.recapture_sq.is_some_and(|sq| sq == mv.to());
         let is_mate_score = Score::is_mate(best_score);
 
         // Late Move Pruning
-        if !in_check && !is_mate_score && move_count >= 2 {
+        if !in_check && !is_recapture && !is_mate_score && move_count >= 2 {
             break;
         }
 


### PR DESCRIPTION
```
Elo   | 3.33 +- 2.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 4.00]
Games | N: 17520 W: 4616 L: 4448 D: 8456
Penta | [66, 2000, 4473, 2142, 79]
```
https://chess.n9x.co/test/4710/