### PR TITLE
Reuse static eval in singular search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -222,12 +222,14 @@ fn alpha_beta(board: &Board,
     // Obtain a static evaluation of the current board state. In leaf nodes, this is the final score
     // used in search. In non-leaf nodes, it is used as a guide for several heuristics, such as
     // extensions, reductions and pruning.
-    let mut static_eval = Score::MIN;
-
-    if !in_check {
+    let static_eval = if singular_search {
+        td.ss[ply].static_eval
+    } else if !in_check {
         let raw_eval = td.nnue.evaluate(board);
         let correction = td.correction_history.correction(board, &td.ss, ply);
-        static_eval = raw_eval + correction;
+        raw_eval + correction
+    } else {
+        Score::MIN
     };
 
     td.ss[ply].static_eval = static_eval;


### PR DESCRIPTION
```
Benchmark 1: ../main/hobbes-chess-engine bench
  Time (mean ± σ):      1.128 s ±  0.013 s    [User: 1.118 s, System: 0.008 s]
  Range (min … max):    1.107 s …  1.146 s    10 runs
 
Benchmark 2: ../dev/hobbes-chess-engine bench
  Time (mean ± σ):      1.126 s ±  0.017 s    [User: 1.115 s, System: 0.009 s]
  Range (min … max):    1.110 s …  1.155 s    10 runs
 
Summary
  ../dev/hobbes-chess-engine bench ran
    1.00 ± 0.02 times faster than ../main/hobbes-chess-engine bench
```

bench 1818616