### PR TITLE
Return fail-firm score in multicut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -503,7 +503,7 @@ fn alpha_beta(board: &Board,
                 extension = 1;
                 extension += (!pv_node && score < s_beta - se_double_ext_margin()) as i32;
             } else if s_beta >= beta {
-                return s_beta;
+                return (s_beta * s_depth + beta) / (s_depth + 1);
             } else if tt_score >= beta {
                 extension = -3;
             } else if cut_node {


### PR DESCRIPTION
```
Elo   | 2.91 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.68 (-2.23, 2.55) [0.00, 4.00]
Games | N: 22206 W: 5786 L: 5600 D: 10820
Penta | [86, 2502, 5755, 2660, 100]
```
https://chess.n9x.co/test/4893/

bench 1910302