### PR TITLE
SPSA tune 40k LTC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export CARGO_BUILD_JOBS := $(JOBS)
 export CARGO_INCREMENTAL := 1
 
 openbench: download-net
-	cargo rustc --release -p hobbes-chess-engine --features "tuning" --jobs $(JOBS) -- $(RUSTFLAGS) --emit link=$(EXE)
+	cargo rustc --release -p hobbes-chess-engine --jobs $(JOBS) -- $(RUSTFLAGS) --emit link=$(EXE)
 
 download-net:
 	$(info Downloading network $(DEFAULT_NET).nnue)


### PR DESCRIPTION
```
Elo   | 2.60 +- 2.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 27682 W: 6799 L: 6592 D: 14291
Penta | [35, 3194, 7187, 3379, 46]
```
https://chess.n9x.co/test/4902/