### PR TITLE
Only check hard time every 2048 nodes

### DIFF
--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -132,6 +132,12 @@ impl ThreadData {
     }
 
     pub fn hard_limit_reached(&self) -> bool {
+
+        // Only check hard limits every 2048 nodes to reduce overhead
+        if self.nodes % 2048 != 0 {
+            return false;
+        }
+
         if let Some(hard_time) = self.limits.hard_time {
             if self.start_time.elapsed() >= hard_time {
                 return true;


### PR DESCRIPTION
```
Elo   | 10.39 +- 6.18 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.06 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3310 W: 948 L: 849 D: 1513
Penta | [17, 329, 870, 416, 23]
https://chess.n9x.co/test/5012/
```

bench 1939472