### PR TITLE
Cutnode-based TT reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -368,7 +368,7 @@ fn alpha_beta(board: &Board,
         depth -= 1;
     }
 
-    // Cutnode-based TT reduction.
+    // Cutnode TT reduction.
     if cut_node
         && !singular_search
         && depth >= 8


### PR DESCRIPTION
```
Elo   | 5.22 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.09 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11776 W: 2965 L: 2788 D: 6023
Penta | [55, 1323, 2952, 1506, 52]
```
https://chess.n9x.co/test/5213/