### PR TITLE
Increase futility pruning margin for killer moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -426,7 +426,8 @@ fn alpha_beta(board: &Board,
         let futility_margin = fp_base()
             + fp_scale() * lmr_depth
             - legal_moves * fp_movecount_mult()
-            + history_score / fp_history_divisor();
+            + history_score / fp_history_divisor()
+            + is_killer as i32 * 25;
         if !root_node
             && !in_check
             && is_quiet


### PR DESCRIPTION
```
Elo   | 4.77 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12810 W: 3196 L: 3020 D: 6594
Penta | [42, 1512, 3141, 1648, 62]
```
https://chess.n9x.co/test/5220/

bench 1727689