### PR TITLE
Fail-medium in q-search stand pat

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -845,7 +845,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
             alpha = static_eval
         }
         if alpha >= beta {
-            return alpha;
+            return (alpha + beta) / 2;
         }
     }
 


### PR DESCRIPTION
```
Elo   | 4.00 +- 2.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 15914 W: 3969 L: 3786 D: 8159
Penta | [67, 1854, 3939, 2023, 74]
```
https://chess.n9x.co/test/5231/

bench 1786404