### PR TITLE
Don't prune killers in q-search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -878,15 +878,16 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         let is_quiet = captured.is_none();
         let is_recapture = board.recapture_sq.is_some_and(|sq| sq == mv.to());
         let is_mate_score = Score::is_mate(best_score);
+        let is_killer = td.ss[ply].killer.is_some_and(|k| k == mv);
 
         // Late Move Pruning
-        if !in_check && !is_recapture && !is_mate_score && move_count >= 2 {
+        if !in_check && !is_recapture && !is_killer && !is_mate_score && move_count >= 2 {
             break;
         }
 
         // Futility Pruning
         // Skip captures that don't win material when the static eval is far below alpha.
-        if !in_check && !is_mate_score && futility_margin <= alpha && !see::see(board, &mv, 1) {
+        if !in_check && !is_mate_score && !is_killer && futility_margin <= alpha && !see::see(board, &mv, 1) {
             if best_score < futility_margin {
                 best_score = futility_margin;
             }
@@ -895,7 +896,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
 
         // SEE Pruning
         // Skip moves which lose material once all the pieces are swapped off.
-        if !in_check && !see::see(board, &mv, qs_see_threshold()) {
+        if !in_check && !is_killer && !see::see(board, &mv, qs_see_threshold()) {
             continue;
         }
 


### PR DESCRIPTION
```
Elo   | 1.91 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 52950 W: 13024 L: 12733 D: 27193
Penta | [213, 6241, 13288, 6508, 225]
```
https://chess.n9x.co/test/5240/

bench 1646593