### PR TITLE
Clear next ply's killer

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -244,6 +244,7 @@ fn alpha_beta(board: &Board,
 
     td.ss[ply].raw_eval = raw_eval;
     td.ss[ply].static_eval = static_eval;
+    td.ss[ply + 1].killer = None;
 
     // We are 'improving' if the static eval of the current position is greater than it was on our
     // previous turn. If improving, we can be more aggressive in our beta pruning - where the eval


### PR DESCRIPTION
```
Elo   | 1.72 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 67316 W: 16449 L: 16115 D: 34752
Penta | [273, 7932, 16925, 8244, 284]
```
https://chess.n9x.co/test/5265/

bench 1847217