### PR TITLE
Use both from/to and piece/to indexing in quiet history

### DIFF
--- a/src/search/movepicker.rs
+++ b/src/search/movepicker.rs
@@ -164,9 +164,9 @@ impl MovePicker {
                 .history
                 .capture_history_score(board, mv, attacker, victim);
             entry.score = victim_value + history_score;
-        } else {
+        } else if let Some(pc) = board.piece_at(mv.from()) {
             // Score quiet
-            let quiet_score = td.history.quiet_history_score(board, mv, threats);
+            let quiet_score = td.history.quiet_history_score(board, mv, pc, threats);
             let cont_score = td.history.cont_history_score(board, &td.stack, mv, ply);
             let is_killer = td.stack[ply].killer == Some(*mv);
             let base = if is_killer { 10000000 } else { 0 };


### PR DESCRIPTION
```
Elo   | 7.78 +- 4.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.00]
Games | N: 6972 W: 1724 L: 1568 D: 3680
Penta | [20, 785, 1729, 923, 29]
```
https://chess.n9x.co/test/5336/

bench 1413302