### PR TITLE
Add tunable for quiethist lerp factor + refactor

### DIFF
--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -95,6 +95,7 @@ tunable_params! {
     quiet_hist_malus_offset     = 15, 0, 200, 25;
     quiet_hist_ttmove_malus     = 76, 0, 200, 25;
     quiet_hist_malus_max        = 1316, 1000, 1600, 100;
+    quiet_hist_lerp_factor      = 50, 0, 100, 5;
     capt_hist_bonus_scale       = 251, 80, 280, 40;
     capt_hist_bonus_offset      = 59, 0, 200, 25;
     capt_hist_ttmove_bonus      = 62, 0, 200, 25;


### PR DESCRIPTION
```
Elo   | 0.39 +- 2.29 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.01 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 22148 W: 5519 L: 5494 D: 11135
Penta | [93, 2385, 6094, 2408, 94]
```
https://chess.n9x.co/test/5337/

bench 1413302