### PR TITLE
Use total conthist score as base for individual conthist updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -594,7 +594,7 @@ fn alpha_beta<NODE: NodeType>(
 
                     if is_quiet && (score <= alpha || score >= beta) {
                         let bonus = lmr_conthist_bonus(depth, score >= beta);
-                        td.history.update_continuation_history(&td.stack, ply, &mv, pc, bonus);
+                        td.history.update_continuation_history(&original_board, &td.stack, ply, &mv, pc, bonus);
                     }
                 }
             }
@@ -715,7 +715,7 @@ fn alpha_beta<NODE: NodeType>(
             td.stack[ply].killer = Some(best_move);
             let pc = board.piece_at(best_move.from()).unwrap();
             td.history.quiet_history.update(board.stm, &best_move, pc, threats, quiet_bonus);
-            td.history.update_continuation_history(&td.stack, ply, &best_move, pc, cont_bonus);
+            td.history.update_continuation_history(board, &td.stack, ply, &best_move, pc, cont_bonus);
             td.history.from_history.update(board.stm, best_move.from(), from_bonus);
             td.history.to_history.update(board.stm, best_move.to(), to_bonus);
 
@@ -724,7 +724,7 @@ fn alpha_beta<NODE: NodeType>(
                 if mv != &best_move {
                     let pc = board.piece_at(mv.from()).unwrap();
                     td.history.quiet_history.update(board.stm, mv, pc, threats, quiet_malus);
-                    td.history.update_continuation_history(&td.stack, ply, mv, pc, cont_malus);
+                    td.history.update_continuation_history(board, &td.stack, ply, mv, pc, cont_malus);
                     td.history.from_history.update(board.stm, mv.from(), from_malus);
                     td.history.to_history.update(board.stm, mv.to(), to_malus);
                 }


### PR DESCRIPTION
```
Elo   | 10.61 +- 5.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4682 W: 1198 L: 1055 D: 2429
Penta | [11, 488, 1207, 617, 18]
```
https://chess.n9x.co/test/5368/

bench 1373700