### PR TITLE
Revert time management changes

### DIFF
--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -58,7 +58,7 @@ impl Default for ThreadData {
             node_table: NodeTable::default(),
             #[cfg(debug_assertions)]
             debug_stats: DebugStatsMap::default(),
-            limits: SearchLimits::new(None, None, None, None, None, 0),
+            limits: SearchLimits::new(None, None, None, None, None),
             start_time: Instant::now(),
             nodes: 0,
             depth: 1,

--- a/src/search/time.rs
+++ b/src/search/time.rs
@@ -21,12 +21,11 @@ impl SearchLimits {
         movetime: Option<u64>,
         soft_nodes: Option<u64>,
         hard_nodes: Option<u64>,
-        depth: Option<u64>,
-        fm_clock: usize,
+        depth: Option<u64>
     ) -> SearchLimits {
         let (soft_time, hard_time) = match (fischer, movetime) {
             (Some(f), _) => {
-                let (soft, hard) = Self::calc_time_limits(f, fm_clock);
+                let (soft, hard) = Self::calc_time_limits(f);
                 (Some(soft), Some(hard))
             }
             (None, Some(mt)) => {
@@ -66,7 +65,7 @@ impl SearchLimits {
         (1.5 - fraction) * 1.35
     }
 
-    fn calc_time_limits(fischer: FischerTime, fm_clock: usize) -> (Duration, Duration) {
+    fn calc_time_limits(fischer: FischerTime) -> (Duration, Duration) {
         let (time, inc) = (fischer.0 as f64, fischer.1 as f64);
         let base = time * 0.05 + inc * 0.08;
         let soft_time = base * 0.66;

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -63,7 +63,7 @@ pub fn bench(td: &mut ThreadData) {
     let mut nodes: u64 = 0;
     let mut time: u64 = 0;
     td.clear();
-    td.limits = SearchLimits::new(None, None, None, None, Some(BENCH_DEPTH), 0);
+    td.limits = SearchLimits::new(None, None, None, None, Some(BENCH_DEPTH));
 
     for fen in FENS {
         let board = Board::from_fen(fen).unwrap();

--- a/src/tools/uci.rs
+++ b/src/tools/uci.rs
@@ -369,8 +369,7 @@ impl UCI {
             movetime,
             softnodes,
             nodes,
-            depth,
-            self.board.fm as usize,
+            depth
         );
 
         // Perform the search


### PR DESCRIPTION
+33 at STC, simplified at LTC for +15 👎 

```
Elo   | 15.46 +- 8.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 2608 W: 853 L: 737 D: 1018
Penta | [4, 369, 547, 275, 109]
```
https://chess.n9x.co/test/5378/