### PR TITLE
Remove q-search capthist

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -988,28 +988,6 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         }
     }
 
-    // Update capture history table
-    if best_move.exists() {
-        let pc = board.piece_at(best_move.from()).unwrap();
-        let capt_bonus = qs_capthist_bonus(1);
-        let capt_malus = qs_capthist_malus(1);
-        if let Some(captured) = board.captured(&best_move) {
-            // If the best move was a capture, give it a capture history bonus.
-            td.history
-                .capture_history
-                .update(board.stm, pc, &best_move, captured, capt_bonus);
-        }
-        for mv in captures.iter() {
-            if mv != &best_move {
-                if let Some(captured) = board.captured(mv) {
-                    td.history
-                        .capture_history
-                        .update(board.stm, pc, mv, captured, capt_malus);
-                }
-            }
-        }
-    }
-
     if move_count == 0 && in_check {
         return -Score::MATE + ply as i32;
     }


### PR DESCRIPTION
Passed LTC simplification:
```
Elo   | 1.11 +- 2.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14666 W: 3414 L: 3367 D: 7885
Penta | [13, 1694, 3870, 1745, 11]
```
https://chess.n9x.co/test/5388/

bench 1483940