### PR TITLE
Add support for PV UCI output

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1097,16 +1097,6 @@ fn print_search_info(board: &Board, td: &mut ThreadData) {
             break;
         }
     }
-
-    // TODO fix illegal PV moves
-    // for mv in td.pv.line() {
-    //     print!(" {}", mv.to_uci());
-    // }
-    //
-    // if td.pv.line().is_empty() {
-    //     print!(" {}", td.pv.best_move().to_uci());
-    // }
-    // print!(" {}", td.best_move.to_uci());
     println!();
 }
 


### PR DESCRIPTION
```
Elo   | 0.04 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 27330 W: 6482 L: 6479 D: 14369
Penta | [72, 2789, 7946, 2780, 78]
```
https://chess.n9x.co/test/5405/