### PR TITLE
Decrease SE depth + increment if TTPV

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -506,7 +506,7 @@ fn alpha_beta<NODE: NodeType>(
             && !singular_search
             && tt_hit
             && mv == tt_move
-            && depth >= se_min_depth()
+            && depth >= se_min_depth() + tt_pv as i32
             && tt_flag != TTFlag::Upper
             && tt_depth >= depth - se_tt_depth_offset() {
 

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -53,7 +53,7 @@ tunable_params! {
     pvs_see_quiet_history_div   = 260, 164, 388, 25;
     pvs_see_noisy_history_div   = 234, 164, 388, 25;
     pvs_see_quiet_ttpv_scale    = 27, 0, 36, 6;
-    se_min_depth                = 8, 6, 10, 1;
+    se_min_depth                = 6, 6, 10, 1;
     se_tt_depth_offset          = 3, 1, 6, 1;
     se_beta_scale               = 16, 16, 48, 6;
     se_depth_offset             = 1, 0, 3, 1;


### PR DESCRIPTION
STC:
```
Elo   | 5.57 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.57 (-2.23, 2.55) [0.00, 5.00]
Games | N: 7804 W: 1952 L: 1827 D: 4025
Penta | [46, 851, 1990, 962, 53]
```
https://chess.n9x.co/test/5421/

LTC:
```
Elo   | 5.16 +- 3.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 10564 W: 2482 L: 2325 D: 5757
Penta | [12, 1176, 2747, 1337, 10]
```
https://chess.n9x.co/test/5423/