### PR TITLE
Score stability

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -49,6 +49,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
     let mut delta = asp_delta();
     let mut reduction = 0;
     let mut prev_mv = Move::NONE;
+    let mut prev_score: i32 = 0;
 
     // Iterative Deepening
     // Search the position to a fixed depth, increasing the depth each iteration until the maximum
@@ -71,12 +72,20 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
             if td.main && !td.minimal_output {
                 print_search_info(board, td);
             }
+
             if prev_mv == td.best_move {
                 td.best_move_stability += 1;
             } else {
                 td.best_move_stability = 0;
             }
             prev_mv = td.best_move;
+
+            if score - prev_score.abs() < score_stability_threshold() {
+                td.score_stability += 1;
+            } else {
+                td.score_stability = 0;
+            }
+            prev_score = score;
 
             if td.should_stop(Hard) || Score::is_mate(score) {
                 break;

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -164,4 +164,5 @@ tunable_params! {
     qs_see_threshold            = -77, -200, 100, 25;
     movepick_see_divisor        = 45, 30, 60, 2;
     movepick_see_offset         = 113, 80, 200, 10;
+    score_stability_threshold   = 12, 4, 24, 2;
 }

--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -32,6 +32,7 @@ pub struct ThreadData {
     pub limits: SearchLimits,
     pub start_time: Instant,
     pub best_move_stability: u32,
+    pub score_stability: u32,
     pub nodes: u64,
     pub depth: i32,
     pub seldepth: usize,
@@ -62,6 +63,7 @@ impl Default for ThreadData {
             limits: SearchLimits::new(None, None, None, None, None, 0),
             start_time: Instant::now(),
             best_move_stability: 0,
+            score_stability: 0,
             nodes: 0,
             depth: 1,
             seldepth: 0,
@@ -82,6 +84,7 @@ impl ThreadData {
         self.best_move = Move::NONE;
         self.best_score = 0;
         self.best_move_stability = 0;
+        self.score_stability = 0;
     }
 
     pub fn clear(&mut self) {
@@ -110,10 +113,14 @@ impl ThreadData {
     pub fn soft_limit_reached(&self) -> bool {
         let best_move_nodes = self.node_table.get(&self.best_move);
         let best_move_stability = self.best_move_stability as u64;
+        let score_stability = self.score_stability as u64;
 
-        if let Some(soft_time) =
-            self.limits
-                .scaled_soft_limit(self.depth, self.nodes, best_move_nodes, best_move_stability)
+        if let Some(soft_time) = self.limits.scaled_soft_limit(
+                self.depth,
+                self.nodes,
+                best_move_nodes,
+                best_move_stability,
+                score_stability)
         {
             if self.start_time.elapsed() >= soft_time {
                 return true;

--- a/src/search/time.rs
+++ b/src/search/time.rs
@@ -51,17 +51,19 @@ impl SearchLimits {
         nodes: u64,
         best_move_nodes: u64,
         best_move_stability: u64,
+        score_stability: u64,
     ) -> Option<Duration> {
         self.soft_time.map(|soft_time| {
             let scaled =
                 soft_time.as_secs_f32()
-                    * self.node_tm_scale(depth, nodes, best_move_nodes)
-                    * Self::best_move_stability_scale(best_move_stability);
+                    * Self::node_tm_scale(depth, nodes, best_move_nodes)
+                    * Self::best_move_stability_scale(best_move_stability)
+                    * Self::score_stability_scale(score_stability);
             Duration::from_secs_f32(scaled)
         })
     }
 
-    const fn node_tm_scale(&self, depth: i32, nodes: u64, best_move_nodes: u64) -> f32 {
+    const fn node_tm_scale(depth: i32, nodes: u64, best_move_nodes: u64) -> f32 {
         if depth < 4 || best_move_nodes == 0 {
             return 1.0;
         }
@@ -71,6 +73,10 @@ impl SearchLimits {
 
     const fn best_move_stability_scale(stability: u64) -> f32 {
         (1.8 - 0.1 * (stability as f32)).max(0.9)
+    }
+
+    const fn score_stability_scale(stability: u64) -> f32 {
+        (1.2 - 0.04 * stability as f32).max(0.88)
     }
 
     fn calc_time_limits(fischer: FischerTime, fm_clock: usize) -> (Duration, Duration) {


### PR DESCRIPTION
STC:
```
Elo   | 6.16 +- 3.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8804 W: 2173 L: 2017 D: 4614
Penta | [19, 925, 2367, 1063, 28]
```
https://chess.n9x.co/test/5574/

LTC (we merge those):
```
Elo   | 2.36 +- 2.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.23 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12530 W: 2873 L: 2788 D: 6869
Penta | [12, 1328, 3493, 1427, 5]
```
https://chess.n9x.co/test/5576/