### PR TITLE
Decrease negative extension when `tt_score >= beta` in PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -546,7 +546,7 @@ fn alpha_beta<NODE: NodeType>(
             } else if s_beta >= beta {
                 return (s_beta * s_depth + beta) / (s_depth + 1);
             } else if tt_score >= beta {
-                extension = -3;
+                extension = -3 + pv_node as i32;
             } else if cut_node {
                 extension = -2;
             } else if tt_score <= alpha {


### PR DESCRIPTION
STC:
```
Elo   | 3.04 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 22318 W: 5236 L: 5041 D: 12041
Penta | [91, 2489, 5798, 2696, 85]
https://chess.n9x.co/test/5678/
```

LTC:
```
Elo   | 3.27 +- 2.43 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 18608 W: 4289 L: 4114 D: 10205
Penta | [12, 2058, 4996, 2219, 19]
```
https://chess.n9x.co/test/5679/