### PR TITLE
Add mock Threads UCI option

### DIFF
--- a/src/tools/uci.rs
+++ b/src/tools/uci.rs
@@ -89,6 +89,7 @@ impl UCI {
     fn handle_uci(&self) {
         println!("id name Hobbes {}", VERSION);
         println!("id author Dan Kelsey");
+        println!("option name Threads type spin default 1 min 1 max 1");
         println!(
             "option name Hash type spin default {} min 1 max 1024",
             self.td.tt.size_mb()


### PR DESCRIPTION
OpenBench requires that all engines support the Threads options, as per https://github.com/AndyGrant/OpenBench/wiki/Requirements-For-Public-Engines . This change is entirely nonfunctional, it just makes OB/fastchess print fewer warnings on hobbes tests.