### PR TITLE
Update correction history when best move is a bad capture

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -831,7 +831,7 @@ fn alpha_beta<NODE: NodeType>(
     if !in_check
         && !singular_search
         && flag.bounds_match(best_score, static_eval, static_eval)
-        && (!best_move.exists() || !board.is_noisy(&best_move)) {
+        && (!best_move.exists() || !board.is_noisy(&best_move) || !see::see(board, &best_move, 0, Pruning)) {
         td.correction_history.update_correction_history(board, &td.stack, depth, ply, static_eval, best_score);
     }
 


### PR DESCRIPTION
```
Elo   | 4.00 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 15530 W: 3694 L: 3515 D: 8321
Penta | [58, 1788, 3905, 1945, 69]
```
https://chess.n9x.co/test/5923/