### PR TITLE
Stop exceeding time limit on time controls with increment

### DIFF
--- a/src/search/time.rs
+++ b/src/search/time.rs
@@ -120,10 +120,9 @@ impl SearchLimits {
         // Credit to Reckless for this formula for calculating the hard/soft bounds
         let soft_scale =
             SOFT_TM_BASE + SOFT_TM_SCALE * (1.0 - (-SOFT_TM_FM_SCALE * fm_clock as f64).exp());
-        let hard_scale = HARD_TM_SCALE;
         let soft_bound = (soft_scale * max_time as f64 + SOFT_TM_INC_SCALE * inc) as u64;
         let hard_bound =
-            ((hard_scale * max_time as f64 + HARD_TM_INC_SCALE * inc) as u64).min(max_time);
+            ((HARD_TM_SCALE * max_time as f64 + HARD_TM_INC_SCALE * inc) as u64).min(max_time);
         (
             Duration::from_millis(soft_bound),
             Duration::from_millis(hard_bound),


### PR DESCRIPTION
This problem was hidden by OpenBench sending a 1 second time margin to fastchess (a hardcoded feature in OpenBench). In practise, this means the engine can exceed its time limit without forfeiting the match. The issue was only noticed in local tests.

Big thanks to @rwbc for reporting this issue and for helping with the debugging!

Stopping the non-reg early, I would merge this even if it lost elo, since previously I was relying on OpenBench's leniency to avoid forfeiting matches.

```
Elo   | -1.31 +- 5.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.03 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3974 W: 932 L: 947 D: 2095
Penta | [14, 423, 1125, 414, 11]
```
https://openbench.nocturn9x.space/test/5943/