### PR TITLE
Prefetch TT entry in NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -371,6 +371,7 @@ fn alpha_beta<NODE: NodeType>(
             board.make_null_move();
             td.nodes += 1;
             td.keys.push(board.hash());
+            td.tt.prefetch(board.hash());
             let score = -alpha_beta::<NonPV>(&board, td, depth - r, ply + 1, -beta, -beta + 1, !cut_node);
             td.keys.pop();
 


### PR DESCRIPTION
```
Elo   | 2.08 +- 1.65 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 4.00]
Games | N: 44320 W: 10714 L: 10449 D: 23157
Penta | [253, 4592, 12257, 4753, 305]
```
https://openbench.nocturn9x.space/test/5988/