### PR TITLE
Switch 'is mate' to 'is mated' guard in PVS

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -443,7 +443,7 @@ fn alpha_beta<NODE: NodeType>(
         let pc = board.piece_at(mv.from()).unwrap();
         let captured = board.captured(&mv);
         let is_quiet = captured.is_none();
-        let is_mate_score = Score::is_mate(best_score);
+        let is_mated = Score::is_mated(best_score);
         let is_killer = td.stack[ply].killer.is_some_and(|k| k == mv);
         let history_score = td.history.history_score(board, &td.stack, &mv, ply, threats, pc, captured);
         let base_reduction = td.lmr.reduction(depth, legal_moves, is_quiet);
@@ -470,7 +470,7 @@ fn alpha_beta<NODE: NodeType>(
             && !in_check
             && is_quiet
             && lmr_depth < fp_max_depth()
-            && !is_mate_score
+            && !is_mated
             && static_eval + futility_margin <= alpha {
             move_picker.skip_quiets = true;
             continue;
@@ -480,7 +480,7 @@ fn alpha_beta<NODE: NodeType>(
         // Skip quiet moves ordered very late in the list.
         if !pv_node
             && !root_node
-            && !is_mate_score
+            && !is_mated
             && is_quiet
             && depth <= lmp_max_depth()
             && searched_moves > late_move_threshold(depth, improving) {
@@ -491,7 +491,7 @@ fn alpha_beta<NODE: NodeType>(
         // Skip quiet moves that have a bad history score.
         if !pv_node
             && !root_node
-            && !is_mate_score
+            && !is_mated
             && !is_killer
             && is_quiet
             && depth <= hp_max_depth()
@@ -710,7 +710,7 @@ fn alpha_beta<NODE: NodeType>(
             // alpha, we can reduce the search depth for the remaining moves.
             if depth > alpha_raise_min_depth()
                 && depth < alpha_raise_max_depth()
-                && !is_mate_score {
+                && !is_mated {
                 depth -= 1;
             }
 

--- a/src/search/score.rs
+++ b/src/search/score.rs
@@ -12,6 +12,10 @@ impl Score {
         score.abs() >= Score::MATE - MAX_PLY as i32
     }
 
+    pub const fn is_mated(score: i32) -> bool {
+        score <= -Score::MATE + MAX_PLY as i32
+    }
+
     pub const fn is_defined(score: i32) -> bool {
         score >= -Score::MATE && score <= Score::MATE
     }


### PR DESCRIPTION
```
Elo   | 2.67 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 24688 W: 5871 L: 5681 D: 13136
Penta | [71, 2491, 7043, 2655, 84]
```
https://openbench.nocturn9x.space/test/6058/