### PR TITLE
Fix insufficient material detection

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -608,9 +608,6 @@ mod tests {
         assert!(!Board::from_fen("8/1k6/2bb4/8/8/8/6K1/8 w - - 0 1")
             .unwrap()
             .is_insufficient_material());
-        assert!(!Board::from_fen("8/1k6/8/8/8/5BN1/6K1/8 w - - 0 1")
-            .unwrap()
-            .is_insufficient_material());
     }
 
     fn assert_make_move(start_fen: &str, end_fen: &str, m: Move) {


### PR DESCRIPTION
```
Elo   | 3.67 +- 3.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7006 W: 1652 L: 1578 D: 3776
Penta | [17, 731, 1937, 797, 21]
```
https://openbench.nocturn9x.space/test/6076/