### PR TITLE
Tweak s_beta formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -563,8 +563,11 @@ fn alpha_beta<NODE: NodeType>(
                 && tt_flag != Upper
                 && tt_depth >= depth - se_tt_depth_offset() {
 
-                let s_beta_mult = depth * (1 + (tt_pv && !pv_node) as i32);
-                let s_beta = (tt_score - s_beta_mult * se_beta_scale(is_quiet) / 16).max(-Score::MATE + 1);
+                let s_beta_base = se_beta_base(is_quiet);
+                let s_beta_scale = se_beta_scale(is_quiet);
+                let s_beta_div = se_beta_div(is_quiet);
+                let s_beta_margin = (s_beta_base + s_beta_scale * (tt_pv && !pv_node) as i32) * depth / s_beta_div;
+                let s_beta = (tt_score - s_beta_margin).max(-Score::MATE + 1);
                 let s_depth = (depth - se_depth_offset()) / se_depth_divisor();
 
                 // Do a reduced-depth search with the TT move excluded.
@@ -1163,11 +1166,29 @@ fn late_move_threshold(depth: i32, improvement: i32) -> i32 {
 }
 
 #[inline]
+fn se_beta_base(is_quiet: bool) -> i32 {
+    if is_quiet {
+        se_beta_quiet_base()
+    } else {
+        se_beta_noisy_base()
+    }
+}
+
+#[inline]
 fn se_beta_scale(is_quiet: bool) -> i32 {
     if is_quiet {
         se_beta_quiet_scale()
     } else {
         se_beta_noisy_scale()
+    }
+}
+
+#[inline]
+fn se_beta_div(is_quiet: bool) -> i32 {
+    if is_quiet {
+        se_beta_quiet_div()
+    } else {
+        se_beta_noisy_div()
     }
 }
 

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -70,10 +70,14 @@ tunable_params! {
     se_tt_depth_offset           = 3, 1..=6,               false;
     se_depth_offset              = 1, 0..=3,               false;
     se_depth_divisor             = 2, 1..=4,               false;
+    se_beta_quiet_base           = 60, 0..=100,            true;
     se_beta_quiet_scale          = 17, 16..=48,            true;
+    se_beta_quiet_div            = 55, 40..=100,           true;
     se_dext_quiet_margin         = 8, 0..=30,              true;
     se_text_quiet_margin         = 64, 20..=120,           true;
+    se_beta_noisy_base           = 60, 0..=100,            true;
     se_beta_noisy_scale          = 19, 16..=48,            true;
+    se_beta_noisy_div            = 55, 40..=100,           true;
     se_dext_noisy_margin         = 9, 0..=30,              true;
     se_text_noisy_margin         = 49, 20..=120,           true;
     ldse_max_depth               = 7, 1..=12,              false;


### PR DESCRIPTION
It gains in the tune, trust me.

```
Elo   | -0.48 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 4.00]
Games | N: 23214 W: 5483 L: 5515 D: 12216
Penta | [83, 2783, 5900, 2765, 76]
```
https://openbench.nocturn9x.space/test/6516/

```
Elo   | 1.64 +- 1.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.34 (-2.25, 2.89) [0.00, 4.00]
Games | N: 29792 W: 7041 L: 6900 D: 15851
Penta | [17, 3429, 7868, 3560, 22]
```
https://openbench.nocturn9x.space/test/6517/