### PR TITLE
Use singular move score in LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -398,6 +398,7 @@ fn alpha_beta<NODE: NodeType>(
     }
 
     let mut extension = 0;
+    let mut singular_score = Score::MIN;
 
     // Singular Extensions
     // Do a reduced-depth search with the TT move excluded. If the result of that search plus
@@ -421,14 +422,14 @@ fn alpha_beta<NODE: NodeType>(
 
             // Do a reduced-depth search with the TT move excluded.
             td.stack[ply].singular = Some(tt_move);
-            let score = alpha_beta::<NonPV>(board, td, s_depth, ply, s_beta - 1, s_beta, cut_node);
+            singular_score = alpha_beta::<NonPV>(board, td, s_depth, ply, s_beta - 1, s_beta, cut_node);
             td.stack[ply].singular = None;
 
-            if score < s_beta {
+            if singular_score < s_beta {
                 // If the reduced search fails to beat s_beta, then we assume the TT move is singular.
                 extension = 1;
-                extension += (!pv_node && score < s_beta - se_dext_margin(is_quiet)) as i32;
-                extension += (!pv_node && is_quiet && score < s_beta - se_text_margin(is_quiet)) as i32;
+                extension += (!pv_node && singular_score < s_beta - se_dext_margin(is_quiet)) as i32;
+                extension += (!pv_node && is_quiet && singular_score < s_beta - se_text_margin(is_quiet)) as i32;
             } else if s_beta >= beta {
                 return (s_beta * s_depth + beta) / (s_depth + 1);
             } else if tt_score >= beta {
@@ -461,6 +462,7 @@ fn alpha_beta<NODE: NodeType>(
     let mut capture_count = 0;
     let mut best_score = Score::MIN;
     let mut best_move = Move::NONE;
+    let mut tt_mv_score = Score::MIN;
     let mut flag = Upper;
 
     let mut quiets = ArrayVec::<Move, 32>::new();
@@ -614,6 +616,10 @@ fn alpha_beta<NODE: NodeType>(
             r += (is_quiet 
                 && original_board.threats.contains(mv.to()) 
                 && !see::see(original_board, &mv, 0, Ordering)) as i32 * lmr_quiet_see();
+            if Score::is_defined(tt_mv_score) && Score::is_defined(singular_score) {
+                let margin = tt_mv_score - singular_score;
+                r += (lmr_se_mult() * (margin - lmr_se_offset()) / lmr_se_div()).clamp(0, lmr_se_max());
+            }
 
             let min_reduced_depth = 1;
             let max_reduced_depth = new_depth + (1 + (legal_moves <= 3) as i32);
@@ -680,6 +686,10 @@ fn alpha_beta<NODE: NodeType>(
 
         if td.should_stop(Hard) {
             break;
+        }
+
+        if mv == tt_move {
+            tt_mv_score = score;
         }
 
         if score > best_score {

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -97,6 +97,10 @@ tunable_params! {
     lmr_shallow                  = 929, 0..=2048,          true;
     lmr_killer                   = 975, 0..=2048,          true;
     lmr_quiet_see                = 1320, 0..=2048,         true;
+    lmr_se_mult                  = 512, 256..=1024,        true;
+    lmr_se_offset                = 160, 0..=1024,          true;
+    lmr_se_div                   = 128, 64..=256,          true;
+    lmr_se_max                   = 2048, 0..=3072,         true;
     lmr_hist_offset              = 1019, -2048..=2048,     true;
     lmr_hist_divisor             = 18352, 8192..=32768,    true;
     lmr_mvv_divisor              = 3, 1..=5,               true;


### PR DESCRIPTION
```
Elo   | 2.44 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 30532 W: 7150 L: 6936 D: 16446
Penta | [60, 3460, 8013, 3672, 61]
```
https://openbench.nocturn9x.space/test/6543/

bench 2904279