### PR TITLE
Reduce LMR depth in cut nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -488,7 +488,7 @@ fn alpha_beta<NODE: NodeType>(
         let is_killer = td.stack[ply].killer.is_some_and(|k| k == mv);
         let history_score = td.history.history_score(board, &td.stack, &mv, ply, threats, pc, captured);
         let base_reduction = td.lmr.reduction(depth, legal_moves, is_quiet);
-        let lmr_depth = depth.saturating_sub(base_reduction);
+        let lmr_depth = depth.saturating_sub(base_reduction).saturating_sub(cut_node as i32);
 
         // Check Extensions
         // If we are in check then the position is likely tactical, so we extend the search depth.


### PR DESCRIPTION
```
Elo   | 1.80 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.00]
Games | N: 58462 W: 13879 L: 13576 D: 31007
Penta | [141, 6837, 15001, 7082, 170]
```
https://openbench.nocturn9x.space/test/6559/

```
Elo   | 1.77 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.82 (-2.25, 2.89) [0.00, 4.00]
Games | N: 15348 W: 3618 L: 3540 D: 8190
Penta | [14, 1756, 4048, 1850, 6]
```
https://openbench.nocturn9x.space/test/6570/