### PR TITLE
Simplify shallow LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -607,7 +607,6 @@ fn alpha_beta<NODE: NodeType>(
             r += lmr_cut_node() * cut_node as i32;
             r -= lmr_capture() * captured.is_some() as i32;
             r += lmr_improving() * !improving as i32;
-            r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
             r -= lmr_killer() * is_killer as i32;
             r -= (legal_moves == 1) as i32 * extension * 1024 / lmr_extension_divisor();
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -94,7 +94,6 @@ tunable_params! {
     lmr_cut_node                 = 1862, 0..=2048,         true;
     lmr_capture                  = 1291, 0..=2048,         true;
     lmr_improving                = 811, 0..=2048,          true;
-    lmr_shallow                  = 929, 0..=2048,          true;
     lmr_killer                   = 975, 0..=2048,          true;
     lmr_quiet_see                = 1320, 0..=2048,         true;
     lmr_se_mult                  = 512, 256..=1024,        true;


### PR DESCRIPTION
```
Elo   | 0.78 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 24816 W: 5862 L: 5806 D: 13148
Penta | [51, 2903, 6445, 2957, 52]
```
https://openbench.nocturn9x.space/test/6617/