### PR TITLE
Multiple small simplifications

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -607,7 +607,6 @@ fn alpha_beta<NODE: NodeType>(
             r += lmr_cut_node() * cut_node as i32;
             r -= lmr_capture() * captured.is_some() as i32;
             r += lmr_improving() * !improving as i32;
-            r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
             r -= lmr_killer() * is_killer as i32;
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c, Ordering) / lmr_mvv_divisor());

--- a/src/search.rs
+++ b/src/search.rs
@@ -526,8 +526,7 @@ fn alpha_beta<NODE: NodeType>(
 
         // History Pruning
         // Skip quiet moves that have a bad history score.
-        if !pv_node
-            && !root_node
+        if !root_node
             && !is_mated
             && !is_killer
             && is_quiet

--- a/src/search.rs
+++ b/src/search.rs
@@ -609,7 +609,6 @@ fn alpha_beta<NODE: NodeType>(
             r += lmr_improving() * !improving as i32;
             r -= lmr_shallow() * (depth == lmr_min_depth()) as i32;
             r -= lmr_killer() * is_killer as i32;
-            r -= (legal_moves == 1) as i32 * extension * 1024 / lmr_extension_divisor();
             r -= is_quiet as i32 * ((history_score - lmr_hist_offset()) / lmr_hist_divisor()) * 1024;
             r -= !is_quiet as i32 * captured.map_or(0, |c| see::value(c, Ordering) / lmr_mvv_divisor());
             r += (is_quiet 

--- a/src/search.rs
+++ b/src/search.rs
@@ -312,9 +312,7 @@ fn alpha_beta<NODE: NodeType>(
             + rfp_scale() * depth
             - rfp_improving_scale() * improving as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
-        if depth <= rfp_max_depth()
-            && static_eval - futility_margin >= beta
-            && tt_flag != Upper {
+        if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
             return beta + (static_eval - beta) / 3;
         }
 

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -103,7 +103,6 @@ tunable_params! {
     lmr_hist_offset              = 1019, -2048..=2048,     true;
     lmr_hist_divisor             = 18352, 8192..=32768,    true;
     lmr_mvv_divisor              = 3, 1..=5,               true;
-    lmr_extension_divisor        = 4, 1..=6,               true;
     lmr_deeper_base              = 23, 0..=100,            true;
     lmr_deeper_scale             = 555, 350..=600,         true;
     lmr_deeper_div               = 166, 64..=256,          true;

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -94,7 +94,6 @@ tunable_params! {
     lmr_cut_node                 = 1862, 0..=2048,         true;
     lmr_capture                  = 1291, 0..=2048,         true;
     lmr_improving                = 811, 0..=2048,          true;
-    lmr_shallow                  = 929, 0..=2048,          true;
     lmr_killer                   = 975, 0..=2048,          true;
     lmr_quiet_see                = 1320, 0..=2048,         true;
     lmr_se_mult                  = 512, 256..=1024,        true;


### PR DESCRIPTION
Simplifications branch
```
Elo   | -0.45 +- 1.59 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 44606 W: 10374 L: 10432 D: 23800
Penta | [50, 5247, 11764, 5195, 47]
```
https://openbench.nocturn9x.space/test/6619/

Allow history pruning in PV nodes
```
Elo   | 1.16 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 20588 W: 4859 L: 4790 D: 10939
Penta | [60, 2426, 5242, 2517, 49]
```
https://openbench.nocturn9x.space/test/6615/

Remove shallow LMR
```
Elo   | 0.78 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 24816 W: 5862 L: 5806 D: 13148
Penta | [51, 2903, 6445, 2957, 52]
```
https://openbench.nocturn9x.space/test/6617/

Remove check extension LMR
```
Elo   | 0.05 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 41762 W: 9761 L: 9755 D: 22246
Penta | [95, 4328, 12003, 4386, 69]
```
https://openbench.nocturn9x.space/test/6616/

Allow RFP if tt failed low
```
Elo   | 1.00 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 22260 W: 5294 L: 5230 D: 11736
Penta | [36, 2645, 5715, 2687, 47]
```
https://openbench.nocturn9x.space/test/6610/