### PR TITLE
Make all fail mediums tunable

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -316,7 +316,7 @@ fn alpha_beta<NODE: NodeType>(
             - rfp_improving_scale() * improving as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
         if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
-            return lerp(beta, static_eval, 33);
+            return lerp(beta, static_eval, rfp_lerp_factor());
         }
 
         // Razoring

--- a/src/search.rs
+++ b/src/search.rs
@@ -28,6 +28,7 @@ use arrayvec::ArrayVec;
 use parameters::*;
 use score::is_mate;
 use SeeType::{Ordering, Pruning};
+use crate::tools::utils::lerp;
 
 pub const MAX_PLY: usize = 256;
 
@@ -315,7 +316,7 @@ fn alpha_beta<NODE: NodeType>(
             - rfp_improving_scale() * improving as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
         if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
-            return beta + (static_eval - beta) / 3;
+            return lerp(beta, static_eval, 33);
         }
 
         // Razoring
@@ -958,7 +959,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
             alpha = static_eval
         }
         if alpha >= beta {
-            return (alpha + beta) / 2;
+            return lerp(alpha, beta, qs_stand_pat_lerp_factor())
         }
     }
 
@@ -1085,7 +1086,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     }
 
     if best_score >= beta && is_defined(best_score) {
-        best_score = (best_score + beta) / 2;
+        best_score = lerp(beta, best_score, qs_fail_high_lerp_factor());
     }
 
     // Write to transposition table

--- a/src/search/history.rs
+++ b/src/search/history.rs
@@ -390,11 +390,6 @@ fn gravity_with_base(current: i32, update: i32, base: i32, max: i32) -> i32 {
     current + update - base * update.abs() / max
 }
 
-/// Linearly interpolate between two history scores, using the provided factor (0-100).
-fn lerp(a: i32, b: i32, factor: i32) -> i32 {
-    (a * (100 - factor) + b * factor) / 100
-}
-
 #[rustfmt::skip]
 mod bonuses {
     use super::*;
@@ -438,3 +433,5 @@ mod bonuses {
                      prior_countermove_malus   (pcm_bonus_scale,           pcm_bonus_offset,           pcm_bonus_max));
 }
 pub use bonuses::*;
+use utils::lerp;
+use crate::tools::utils;

--- a/src/search/history.rs
+++ b/src/search/history.rs
@@ -26,6 +26,7 @@ use crate::search::parameters::{
     to_hist_malus_offset, to_hist_malus_scale,
 };
 use crate::tools::utils::boxed_and_zeroed;
+use crate::tools::utils::lerp;
 
 /// History table storing values of type `T`, indexed by the 'from' and 'to' squares of a move.
 /// Also known as 'butterfly' history.
@@ -433,5 +434,3 @@ mod bonuses {
                      prior_countermove_malus   (pcm_bonus_scale,           pcm_bonus_offset,           pcm_bonus_max));
 }
 pub use bonuses::*;
-use utils::lerp;
-use crate::tools::utils;

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -12,6 +12,7 @@ tunable_params! {
     rfp_scale                    = 61, 40..=100,           true;
     rfp_improving_scale          = 56, 40..=100,           true;
     rfp_tt_move_noisy_scale      = 6, 0..=70,              true;
+    rfp_lerp_factor              = 33, 0..=100,            true;
     razor_base                   = 287, 200..=500,         true;
     razor_scale                  = 263, 100..=400,         true;
     nmp_min_depth                = 3, 0..=8,               false;
@@ -250,6 +251,8 @@ tunable_params! {
     material_scaling_base        = 15739, 10000..=40000,   true;
     qs_futility_threshold        = 173, 80..=250,          true;
     qs_see_threshold             = -95, -200..=100,        true;
+    qs_stand_pat_lerp_factor     = 50, 0..=100,            true;
+    qs_fail_high_lerp_factor     = 50, 0..=100,            true;
     movepick_see_divisor         = 44, 30..=60,            true;
     movepick_see_offset          = 117, 80..=200,          true;
     score_stability_threshold    = 14, 4..=24,             true;

--- a/src/tools/utils.rs
+++ b/src/tools/utils.rs
@@ -72,6 +72,12 @@ macro_rules! tunable_params {
 
 }
 
+/// Linearly interpolate between two scores, using the provided factor (0-100).
+#[inline]
+pub const fn lerp(a: i32, b: i32, factor: i32) -> i32 {
+    (a * (100 - factor) + b * factor) / 100
+}
+
 // Credit to Akimbo author - necessary for boxing large arrays
 // without exploding the stack on initialisation.
 /// # Safety


### PR DESCRIPTION
```
Elo   | 0.36 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 22346 W: 5179 L: 5156 D: 12011
Penta | [75, 2584, 5821, 2629, 64]
```
https://openbench.nocturn9x.space/test/6672/