### PR TITLE
Low-depth singular double extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -450,10 +450,12 @@ fn alpha_beta<NODE: NodeType>(
             && static_eval <= alpha - ldse_margin()
             && tt_flag == Lower {
             extension = 1;
+
+            // If the static eval is very far below alpha, in some scenarios we can extend even further.
             if !pv_node
                 && !tt_move_noisy
-                && tt_depth >= depth - 3
-                && static_eval < alpha - 42 {
+                && tt_depth >= depth - ldse_dext_tt_depth_offset()
+                && static_eval < alpha - ldse_dext_margin() {
                 extension += 1;
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -450,6 +450,12 @@ fn alpha_beta<NODE: NodeType>(
             && static_eval <= alpha - ldse_margin()
             && tt_flag == Lower {
             extension = 1;
+            if !pv_node
+                && !tt_move_noisy
+                && tt_depth >= depth - 3
+                && static_eval < alpha - 42 {
+                extension += 1;
+            }
         }
 
     }

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -83,6 +83,8 @@ tunable_params! {
     se_text_noisy_margin         = 51, 20..=120,           true;
     ldse_max_depth               = 7, 1..=12,              false;
     ldse_margin                  = 25, 0..=80,             true;
+    ldse_dext_tt_depth_offset    = 3, 1..=5,               false;
+    ldse_dext_margin             = 42, 20..=80,            true;
     lmr_min_depth                = 2, 1..=5,               false;
     lmr_min_moves                = 2, 1..=4,               false;
     lmr_quiet_base               = 91, 50..=150,           true;


### PR DESCRIPTION
```
Elo   | 1.58 +- 1.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 80458 W: 19139 L: 18773 D: 42546
Penta | [230, 9391, 20629, 9741, 238]
```
https://openbench.nocturn9x.space/test/6761/