### PR TITLE
Use proper `gives_check` for gives check LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -600,6 +600,8 @@ fn alpha_beta<NODE: NodeType>(
         searched_moves += 1;
         td.nodes += 1;
 
+        let gives_check = board.threats.contains(board.king_sq(board.stm));
+
         let initial_nodes = td.nodes;
         let mut new_depth = depth - 1 + if legal_moves == 1 { extension } else { 0 };
 
@@ -619,7 +621,7 @@ fn alpha_beta<NODE: NodeType>(
             r += lmr_cut_node() * cut_node as i32;
             r -= lmr_capture() * captured.is_some() as i32;
             r -= lmr_in_check() * in_check as i32;
-            r -= lmr_gives_check() * original_board.gives_direct_check(mv) as i32;
+            r -= lmr_gives_check() * gives_check as i32;
             r += lmr_improving() * !improving as i32;
             r -= lmr_good_noisy() * (move_picker.stage == GoodNoisies) as i32;
             r += lmr_bad_noisy() * (move_picker.stage == BadNoisies) as i32;


### PR DESCRIPTION
Stopping non-reg early

```
Elo   | -0.38 +- 1.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.09 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 50422 W: 11737 L: 11792 D: 26893
Penta | [163, 5843, 13235, 5826, 144]
```
https://openbench.nocturn9x.space/test/6801/