### PR TITLE
Fix undefined behaviour in sparse calculation

### DIFF
--- a/src/evaluation/sparse.rs
+++ b/src/evaluation/sparse.rs
@@ -39,7 +39,7 @@ pub unsafe fn find_nonzero_indices(input: &[u8; L1_SIZE]) -> ([u16; L1_SIZE / 4]
     };
     const NUM_CHUNKS: usize = UNROLL * simd::I32_LANES / 8;
 
-    let mut indices = std::mem::MaybeUninit::<[u16; L1_SIZE / 4]>::uninit();
+    let mut indices = [0u16; L1_SIZE / 4];
     let indices_ptr = indices.as_mut_ptr() as *mut u16;
     let mut count = 0usize;
     let mut base = simd::splat_u16(0);
@@ -64,5 +64,5 @@ pub unsafe fn find_nonzero_indices(input: &[u8; L1_SIZE]) -> ([u16; L1_SIZE / 4]
         }
     }
 
-    (indices.assume_init(), count)
+    (indices, count)
 }


### PR DESCRIPTION
```
Elo   | 1.67 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 16238 W: 3735 L: 3657 D: 8846
Penta | [36, 1725, 4534, 1773, 51]
```
https://openbench.nocturn9x.space/test/6818/