### PR TITLE
Merged king planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Hobbes features a classical alpha-beta negamax search with iterative deepening. 
 
 ## Evaluation
 
-Hobbes uses a multilayer, efficiently updated neural network (NNUE) for its evaluation function. The architecture of the network is `(768x16hm->1536pw)x2->(16x2->32->1)x8`. Other NNUE optimisations that Hobbes employs are sparse matrix multiplication, fused refreshes, Finny tables, and lazy updates.
+Hobbes uses a multilayer, efficiently updated neural network (NNUE) for its evaluation function. The architecture of the network is `(704x16hm->1536pw)x2->(16x2->32->1)x8`. Other NNUE optimisations that Hobbes employs are sparse matrix multiplication, fused refreshes, Finny tables, and lazy updates.
 
 The network is trained entirely on data generated from self-play. The training data is a (roughly) 80/20 split of standard data and DFRC data. The network was initialised from random values and trained up over many iterations; the full history of past nets is documented [here](https://github.com/kelseyde/hobbes-chess-engine/blob/main/network_history.txt). All of hobbes' networks have been trained using [bullet](https://github.com/jw1912/bullet).
 

--- a/hobbes-nnue-arch/src/arch.rs
+++ b/hobbes-nnue-arch/src/arch.rs
@@ -13,7 +13,7 @@ pub const BUCKETS: [usize; 64] = [
     14, 14, 15, 15, 15, 15, 14, 14,
 ];
 
-pub const L0_SIZE: usize = 768;
+pub const L0_SIZE: usize = 704;
 pub const L0_QUANT: usize = 255;
 pub const L0_SHIFT: usize = 9;
 

--- a/network.txt
+++ b/network.txt
@@ -1,1 +1,1 @@
-hobbes-41
+hobbes-42

--- a/resources/merged_king_planes.py
+++ b/resources/merged_king_planes.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import numpy as np
+import sys
+
+
+def isMirrored(sq):
+    return sq % 8 >= 4
+
+
+# fmt: off
+LAYOUT = [
+    0,  1,  2,  3, 3, 2,  1,  0,
+    4,  5,  6,  7, 7, 6,  5,  4,
+    8,  8,  9,  9, 9, 9,  8,  8,
+    10, 10, 11, 11, 11, 11, 10, 10,
+    12, 12, 13, 13, 13, 13, 12, 12,
+    12, 12, 13, 13, 13, 13, 12, 12,
+    14, 14, 15, 15, 15, 15, 14, 14,
+    14, 14, 15, 15, 15, 15, 14, 14,
+]
+BUCKETS = max(LAYOUT) + 1
+# fmt: on
+
+HL = 1536
+FT_SIZE = BUCKETS * 12 * 64 * HL
+MERGED_FT_SIZE = BUCKETS * 11 * 64 * HL
+
+net = np.frombuffer(open(sys.argv[1], "rb").read(), dtype=np.int16)
+ft = net[:FT_SIZE].reshape([BUCKETS, 12, 64, HL])
+mergedFt = ft[:, :11, :, :].copy()
+
+friendlyKing = 5
+opponentKing = 11
+
+for bucket in range(BUCKETS):
+    for sq in range(64):
+        if bucket == LAYOUT[sq] and not isMirrored(sq):
+            continue
+        mergedFt[bucket, friendlyKing, sq, :] = ft[bucket, opponentKing, sq, :]
+
+mergedNet = np.concat((mergedFt.reshape(MERGED_FT_SIZE), net[FT_SIZE:]))
+open("merged.nnue", "wb").write(mergedNet.tobytes())

--- a/src/evaluation/feature.rs
+++ b/src/evaluation/feature.rs
@@ -1,6 +1,5 @@
 use crate::board::piece::Piece;
 use crate::board::side::Side;
-use crate::board::side::Side::White;
 use crate::board::square::Square;
 
 /// Represents a single feature used by the neural network. A feature is a piece on a square on the
@@ -14,9 +13,6 @@ pub struct Feature {
     side: Side,
 }
 
-const PIECE_OFFSET: usize = 64;
-const SIDE_OFFSET: usize = 64 * 6;
-
 impl Feature {
     #[inline]
     pub fn new(pc: Piece, sq: Square, side: Side) -> Self {
@@ -25,25 +21,27 @@ impl Feature {
 
     #[inline]
     pub fn index(&self, perspective: Side, mirror: bool) -> usize {
-        let sq_index = self.square_index(perspective, mirror);
-        let pc_offset = self.pc as usize * PIECE_OFFSET;
-        let side_offset = if self.side == perspective {
-            0
-        } else {
-            SIDE_OFFSET
+        let (mut sq, mut color) = match perspective {
+            Side::White => (self.sq, self.side),
+            Side::Black => (self.sq.flip_rank(), !self.side),
         };
-        side_offset + pc_offset + sq_index
+
+        // Horizontal mirroring
+        if mirror {
+            sq = sq.flip_file();
+        }
+
+        // Merged king planes
+        if self.pc == Piece::King {
+            color = Side::White;
+        }
+
+        let sq = sq.0 as usize;
+        let pc = self.pc as usize;
+        let color = color as usize;
+
+        sq + Square::COUNT as usize * (pc + Piece::COUNT * color)
     }
 
-    #[inline]
-    fn square_index(&self, perspective: Side, mirror: bool) -> usize {
-        let mut sq_index = self.sq;
-        if perspective != White {
-            sq_index = sq_index.flip_rank();
-        }
-        if mirror {
-            sq_index = sq_index.flip_file();
-        }
-        sq_index.0 as usize
-    }
+
 }


### PR DESCRIPTION
Thanks to @Sp00ph for the python script to post-process the net. 

Passed non-reg:

```
Elo   | -0.49 +- 1.23 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 83004 W: 19586 L: 19702 D: 43716
Penta | [498, 9279, 22069, 9153, 503]
```
https://openbench.nocturn9x.space/test/6834/