### PR TITLE
Refactor vectorised inference

### DIFF
--- a/src/evaluation/feature.rs
+++ b/src/evaluation/feature.rs
@@ -42,6 +42,4 @@ impl Feature {
 
         sq + Square::COUNT as usize * (pc + Piece::COUNT * color)
     }
-
-
 }

--- a/src/evaluation/forward/vectorised.rs
+++ b/src/evaluation/forward/vectorised.rs
@@ -111,38 +111,25 @@ impl Forward for Vectorised {
         let weights = &NETWORK.l2_weights[output_bucket];
         let biases = &NETWORK.l2_biases[output_bucket];
 
-        let mut acc = [simd::splat_i32(0); LANES];
-        for (lane, acc_lane) in acc.iter_mut().enumerate() {
-            *acc_lane = simd::load_i32(biases.as_ptr().add(lane * simd::I32_LANES));
-        }
+        let mut acc: [simd::VecI32; LANES] =
+            std::array::from_fn(|lane| simd::load_i32(biases.as_ptr().add(lane * simd::I32_LANES)));
 
-        for (&input_scalar, weight_row_arr) in input.iter().zip(weights.iter()) {
+        for (&input_scalar, weight_row) in input.iter().zip(weights.iter()) {
             let input_val = simd::splat_i32(input_scalar);
-            let weight_row = weight_row_arr.as_ptr();
-
-            let mut lane = 0;
-            while lane + 4 <= LANES {
-                let off = lane * simd::I32_LANES;
-                let weight0 = simd::load_i32(weight_row.add(off));
-                let weight1 = simd::load_i32(weight_row.add(off + simd::I32_LANES));
-                let weight2 = simd::load_i32(weight_row.add(off + 2 * simd::I32_LANES));
-                let weight3 = simd::load_i32(weight_row.add(off + 3 * simd::I32_LANES));
-                acc[lane] = simd::mul_add_i32(weight0, input_val, acc[lane]);
-                acc[lane + 1] = simd::mul_add_i32(weight1, input_val, acc[lane + 1]);
-                acc[lane + 2] = simd::mul_add_i32(weight2, input_val, acc[lane + 2]);
-                acc[lane + 3] = simd::mul_add_i32(weight3, input_val, acc[lane + 3]);
-                lane += 4;
-            }
-            while lane < LANES {
-                let weight = simd::load_i32(weight_row.add(lane * simd::I32_LANES));
+            let weight_ptr = weight_row.as_ptr();
+            for lane in 0..LANES {
+                let weight = simd::load_i32(weight_ptr.add(lane * simd::I32_LANES));
                 acc[lane] = simd::mul_add_i32(weight, input_val, acc[lane]);
-                lane += 1;
             }
         }
+
+        let lo = simd::splat_i32(0);
+        let hi3 = simd::splat_i32((Q * Q * Q) as i32);
 
         let mut output = [0i32; L3_SIZE];
         for (lane, acc_lane) in acc.iter().enumerate() {
-            simd::store_i32(output.as_mut_ptr().add(lane * simd::I32_LANES), *acc_lane);
+            let clamped = simd::clamp_i32(*acc_lane, lo, hi3);
+            simd::store_i32(output.as_mut_ptr().add(lane * simd::I32_LANES), clamped);
         }
         output
     }
@@ -151,15 +138,12 @@ impl Forward for Vectorised {
     unsafe fn propagate_l3(input: &[i32; L3_SIZE], output_bucket: usize) -> i32 {
         let weights = NETWORK.l3_weights[output_bucket].as_ptr();
         let bias = NETWORK.l3_biases[output_bucket];
-        let lo = simd::splat_i32(0);
-        let hi = simd::splat_i32((Q * Q * Q) as i32);
 
         let mut sum = simd::splat_i32(0);
         for i in (0..L3_SIZE).step_by(simd::I32_LANES) {
             let input_chunk = simd::load_i32(input.as_ptr().add(i));
             let weight_chunk = simd::load_i32(weights.add(i));
-            let clamped = simd::clamp_i32(input_chunk, lo, hi);
-            sum = simd::add_i32(sum, simd::mul_i32(weight_chunk, clamped));
+            sum = simd::add_i32(sum, simd::mul_i32(weight_chunk, input_chunk));
         }
 
         simd::horizontal_sum_i32_single(sum) + bias

--- a/src/evaluation/forward/vectorised.rs
+++ b/src/evaluation/forward/vectorised.rs
@@ -149,22 +149,19 @@ impl Forward for Vectorised {
 
     /// L3 propagation
     unsafe fn propagate_l3(input: &[i32; L3_SIZE], output_bucket: usize) -> i32 {
-        const LANES: usize = L3_SIZE / simd::I32_LANES;
-
         let weights = NETWORK.l3_weights[output_bucket].as_ptr();
         let bias = NETWORK.l3_biases[output_bucket];
         let lo = simd::splat_i32(0);
         let hi = simd::splat_i32((Q * Q * Q) as i32);
 
-        let mut acc = [simd::splat_i32(0); LANES];
-        for (lane, acc_lane) in acc.iter_mut().enumerate() {
-            let off = lane * simd::I32_LANES;
-            let input_chunk = simd::load_i32(input.as_ptr().add(off));
-            let weight_chunk = simd::load_i32(weights.add(off));
+        let mut sum = simd::splat_i32(0);
+        for i in (0..L3_SIZE).step_by(simd::I32_LANES) {
+            let input_chunk = simd::load_i32(input.as_ptr().add(i));
+            let weight_chunk = simd::load_i32(weights.add(i));
             let clamped = simd::clamp_i32(input_chunk, lo, hi);
-            *acc_lane = simd::mul_i32(weight_chunk, clamped);
+            sum = simd::add_i32(sum, simd::mul_i32(weight_chunk, clamped));
         }
 
-        simd::horizontal_sum_i32(acc) + bias
+        simd::horizontal_sum_i32_single(sum) + bias
     }
 }

--- a/src/evaluation/simd/avx2.rs
+++ b/src/evaluation/simd/avx2.rs
@@ -148,15 +148,6 @@ pub unsafe fn horizontal_sum_i32_single(a: __m256i) -> i32 {
 }
 
 #[inline(always)]
-pub unsafe fn horizontal_sum_i32<const N: usize>(a: [__m256i; N]) -> i32 {
-    let mut acc = a[0];
-    for i in 1..N {
-        acc = _mm256_add_epi32(acc, a[i]);
-    }
-    horizontal_sum_i32_single(acc)
-}
-
-#[inline(always)]
 pub unsafe fn dpbusdx2(
     acc: __m256i,
     u1: __m256i,

--- a/src/evaluation/simd/avx512.rs
+++ b/src/evaluation/simd/avx512.rs
@@ -144,15 +144,6 @@ pub unsafe fn horizontal_sum_i32_single(a: __m512i) -> i32 {
 }
 
 #[inline(always)]
-pub unsafe fn horizontal_sum_i32<const N: usize>(a: [__m512i; N]) -> i32 {
-    let mut acc = a[0];
-    for i in 1..N {
-        acc = _mm512_add_epi32(acc, a[i]);
-    }
-    horizontal_sum_i32_single(acc)
-}
-
-#[inline(always)]
 pub unsafe fn dpbusdx2(
     acc: __m512i,
     u1: __m512i,

--- a/src/evaluation/simd/neon.rs
+++ b/src/evaluation/simd/neon.rs
@@ -197,12 +197,3 @@ pub unsafe fn shift_right_i32<const SHIFT: i32>(a: int32x4_t) -> int32x4_t {
 pub unsafe fn shift_left_i32<const SHIFT: i32>(a: int32x4_t) -> int32x4_t {
     vshlq_n_s32::<SHIFT>(a)
 }
-
-#[inline(always)]
-pub unsafe fn horizontal_sum_i32<const N: usize>(a: [int32x4_t; N]) -> i32 {
-    let mut acc = a[0];
-    for &lane in a.iter().skip(1) {
-        acc = vaddq_s32(acc, lane);
-    }
-    horizontal_sum_i32_single(acc)
-}


### PR DESCRIPTION
```
Benchmark 1: ./dev/hobbes-chess-engine bench
  Time (mean ± σ):      1.223 s ±  0.002 s    [User: 1.213 s, System: 0.009 s]
  Range (min … max):    1.220 s …  1.229 s    10 runs
 
Benchmark 2: ./main/hobbes-chess-engine bench
  Time (mean ± σ):      1.223 s ±  0.002 s    [User: 1.213 s, System: 0.009 s]
  Range (min … max):    1.221 s …  1.229 s    10 runs
 
Summary
  ./dev/hobbes-chess-engine bench ran
    1.00 ± 0.00 times faster than ./main/hobbes-chess-engine bench
```