### PR TITLE
Adjust RFP margin if opponent is worsening

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -259,6 +259,13 @@ fn alpha_beta<NODE: NodeType>(
     let improvement = calc_improvement(td, ply, static_eval, in_check);
     let improving = improvement > 0;
 
+    let opponent_worsening_rate = if root_node || in_check {
+        0
+    } else {
+        static_eval + td.stack[ply - 1].static_eval
+    };
+    let opponent_worsening = opponent_worsening_rate > 0;
+
     // Hindsight history updates
     // Use the difference between the static eval in the current node and parent node to update the
     // history score for the parent move.
@@ -288,7 +295,7 @@ fn alpha_beta<NODE: NodeType>(
         && depth >= hindsight_ext_min_depth()
         && td.stack[ply - 1].reduction >= hindsight_ext_min_reduction()
         && is_defined(td.stack[ply - 1].static_eval)
-        && static_eval + td.stack[ply - 1].static_eval < hindsight_ext_eval_diff() {
+        && opponent_worsening_rate < hindsight_ext_eval_diff() {
         depth += 1;
     }
 
@@ -302,7 +309,7 @@ fn alpha_beta<NODE: NodeType>(
         && depth >= hindsight_red_min_depth()
         && td.stack[ply - 1].reduction >= hindsight_red_min_reduction()
         && is_defined(td.stack[ply - 1].static_eval)
-        && static_eval + td.stack[ply - 1].static_eval > hindsight_red_eval_diff() {
+        && opponent_worsening_rate > hindsight_red_eval_diff() {
         depth -= 1;
     }
 
@@ -315,6 +322,7 @@ fn alpha_beta<NODE: NodeType>(
         let futility_margin = rfp_base()
             + rfp_scale() * depth
             - rfp_improving_scale() * improving as i32
+            - rfp_opp_worsening_scale() * opponent_worsening as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
         if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
             return lerp(beta, static_eval, rfp_lerp_factor());

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -11,6 +11,7 @@ tunable_params! {
     rfp_base                     = 11, -50..=50,           true;
     rfp_scale                    = 60, 40..=100,           true;
     rfp_improving_scale          = 55, 40..=100,           true;
+    rfp_opp_worsening_scale      = 15, 0..=50,             true;
     rfp_tt_move_noisy_scale      = 7, 0..=70,              true;
     rfp_lerp_factor              = 34, 0..=100,            true;
     razor_base                   = 283, 200..=500,         true;


### PR DESCRIPTION
```
Elo   | 3.51 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22676 W: 5502 L: 5273 D: 11901
Penta | [103, 2625, 5676, 2808, 126]
```
https://openbench.nocturn9x.space/test/6836/