### PR TITLE
Minor packus NEON optimisation

### DIFF
--- a/src/evaluation/simd/neon.rs
+++ b/src/evaluation/simd/neon.rs
@@ -130,7 +130,7 @@ pub unsafe fn nonzero_mask_u8(ptr: *const u8) -> u32 {
 
 #[inline(always)]
 pub unsafe fn packus(a: int16x8_t, b: int16x8_t) -> uint8x16_t {
-    vcombine_u8(vqmovun_s16(a), vqmovun_s16(b))
+    vqmovun_high_s16(vqmovun_s16(a), b)
 }
 
 #[inline(always)]


### PR DESCRIPTION
```
Benchmark 1: ./dev/hobbes-chess-engine bench
  Time (mean ± σ):      1.111 s ±  0.003 s    [User: 1.102 s, System: 0.008 s]
  Range (min … max):    1.103 s …  1.113 s    10 runs
 
Benchmark 2: ./main/hobbes-chess-engine bench
  Time (mean ± σ):      1.111 s ±  0.002 s    [User: 1.101 s, System: 0.009 s]
  Range (min … max):    1.107 s …  1.113 s    10 runs
 
Summary
  ./dev/hobbes-chess-engine bench ran
    1.00 ± 0.00 times faster than ./main/hobbes-chess-engine bench
```