### PR TITLE
Make time management paramters tunable

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -41,6 +41,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
     td.pv.clear(0);
     td.nnue.activate(board);
     td.lmr.init();
+    td.limits.init();
 
     let mut root_moves = MoveList::new();
     board.gen_legal_moves(&mut root_moves);

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -264,4 +264,18 @@ tunable_params! {
     movepick_see_divisor         = 45, 30..=60,            true;
     movepick_see_offset          = 118, 80..=200,          true;
     score_stability_threshold    = 14, 4..=24,             true;
+    tm_soft_base                 = 24, 10..=60,            true;
+    tm_soft_scale                = 42, 20..=80,            true;
+    tm_soft_inc_scale            = 750, 400..=1000,        true;
+    tm_soft_fm_scale             = 45, 20..=80,            true;
+    tm_hard_scale                = 742, 400..=1000,        true;
+    tm_hard_inc_scale            = 750, 400..=1000,        true;
+    tm_node_base                 = 1500, 1000..=2000,      true;
+    tm_node_scale                = 1350, 800..=2000,       true;
+    tm_best_move_base            = 1800, 1000..=2500,      true;
+    tm_best_move_scale           = 100, 50..=300,          true;
+    tm_best_move_min             = 900, 500..=1000,        true;
+    tm_score_base                = 1200, 800..=1800,       true;
+    tm_score_scale               = 40, 10..=100,           true;
+    tm_score_min                 = 880, 500..=1000,        true;
 }

--- a/src/search/time.rs
+++ b/src/search/time.rs
@@ -1,20 +1,53 @@
 use std::time::Duration;
 
-pub const SOFT_TM_BASE: f64 = 0.024;
-pub const SOFT_TM_SCALE: f64 = 0.042;
-pub const SOFT_TM_INC_SCALE: f64 = 0.75;
-pub const SOFT_TM_FM_SCALE: f64 = 0.045;
-pub const HARD_TM_SCALE: f64 = 0.742;
-pub const HARD_TM_INC_SCALE: f64 = 0.75;
-pub const NODE_TM_BASE: f32 = 1.5;
-pub const NODE_TM_SCALE: f32 = 1.35;
-pub const BEST_MOVE_TM_BASE: f32 = 1.8;
-pub const BEST_MOVE_TM_SCALE: f32 = 0.1;
-pub const BEST_MOVE_TM_MIN: f32 = 0.9;
-pub const SCORE_TM_BASE: f32 = 1.2;
-pub const SCORE_TM_SCALE: f32 = 0.04;
-pub const SCORE_TM_MIN: f32 = 0.88;
+use crate::search::parameters::*;
+
 pub const UCI_OVERHEAD_MS: u64 = 50;
+
+pub struct TimeParams {
+    pub soft_tm_base:        f64,
+    pub soft_tm_scale:       f64,
+    pub soft_tm_inc_scale:   f64,
+    pub soft_tm_fm_scale:    f64,
+    pub hard_tm_scale:       f64,
+    pub hard_tm_inc_scale:   f64,
+    pub node_tm_base:        f32,
+    pub node_tm_scale:       f32,
+    pub best_move_tm_base:   f32,
+    pub best_move_tm_scale:  f32,
+    pub best_move_tm_min:    f32,
+    pub score_tm_base:       f32,
+    pub score_tm_scale:      f32,
+    pub score_tm_min:        f32,
+}
+
+impl TimeParams {
+    pub fn init() -> Self {
+        Self {
+            soft_tm_base:       tm_soft_base() as f64 / 1000.0,
+            soft_tm_scale:      tm_soft_scale() as f64 / 1000.0,
+            soft_tm_inc_scale:  tm_soft_inc_scale() as f64 / 1000.0,
+            soft_tm_fm_scale:   tm_soft_fm_scale() as f64 / 1000.0,
+            hard_tm_scale:      tm_hard_scale() as f64 / 1000.0,
+            hard_tm_inc_scale:  tm_hard_inc_scale() as f64 / 1000.0,
+            node_tm_base:       tm_node_base() as f32 / 1000.0,
+            node_tm_scale:      tm_node_scale() as f32 / 1000.0,
+            best_move_tm_base:  tm_best_move_base() as f32 / 1000.0,
+            best_move_tm_scale: tm_best_move_scale() as f32 / 1000.0,
+            best_move_tm_min:   tm_best_move_min() as f32 / 1000.0,
+            score_tm_base:      tm_score_base() as f32 / 1000.0,
+            score_tm_scale:     tm_score_scale() as f32 / 1000.0,
+            score_tm_min:       tm_score_min() as f32 / 1000.0,
+        }
+    }
+}
+
+pub enum LimitType {
+    Soft,
+    Hard,
+}
+
+pub type FischerTime = (u64, u64);
 
 /// The amount of time the engine chooses to search is split into to two limits: hard and soft. The
 /// hard limit is checked regularly during search, and the search is aborted as soon as it is reached.
@@ -26,19 +59,13 @@ pub const UCI_OVERHEAD_MS: u64 = 50;
 /// remained the same, how stable the search score has been across iterations, or what portion of
 /// nodes have been spent searching the current best move.
 pub struct SearchLimits {
-    pub hard_time: Option<Duration>,
-    pub soft_time: Option<Duration>,
-    pub soft_nodes: Option<u64>,
-    pub hard_nodes: Option<u64>,
-    pub depth: Option<u64>,
+    pub hard_time:   Option<Duration>,
+    pub soft_time:   Option<Duration>,
+    pub soft_nodes:  Option<u64>,
+    pub hard_nodes:  Option<u64>,
+    pub depth:       Option<u64>,
+    pub time_params: TimeParams,
 }
-
-pub enum LimitType {
-    Soft,
-    Hard,
-}
-
-pub type FischerTime = (u64, u64);
 
 impl SearchLimits {
     pub fn new(
@@ -49,9 +76,10 @@ impl SearchLimits {
         depth: Option<u64>,
         fm_clock: usize,
     ) -> SearchLimits {
+        let time_params = TimeParams::init();
         let (soft_time, hard_time) = match (fischer, movetime) {
             (Some(f), _) => {
-                let (soft, hard) = Self::calc_time_limits(f, fm_clock);
+                let (soft, hard) = Self::calc_time_limits(&time_params, f, fm_clock);
                 (Some(soft), Some(hard))
             }
             (None, Some(mt)) => {
@@ -67,7 +95,14 @@ impl SearchLimits {
             soft_nodes,
             hard_nodes,
             depth,
+            time_params,
         }
+    }
+
+    /// Re-initialise the TimeParams from the current tunable values. Call at the top of the main
+    /// search function so that any tunable updates take effect immediately.
+    pub fn init(&mut self) {
+        self.time_params = TimeParams::init();
     }
 
     /// Scale the soft limit based on how stable we think the search is, and therefore how confident
@@ -80,49 +115,46 @@ impl SearchLimits {
         best_move_stability: u64,
         score_stability: u64,
     ) -> Option<Duration> {
+        let p = &self.time_params;
         self.soft_time.map(|soft_time| {
             let scaled = soft_time.as_secs_f32()
-                * Self::node_tm_scale(depth, nodes, best_move_nodes)
-                * Self::best_move_stability_scale(best_move_stability)
-                * Self::score_stability_scale(score_stability);
+                * Self::node_tm_scale(p, depth, nodes, best_move_nodes)
+                * Self::best_move_stability_scale(p, best_move_stability)
+                * Self::score_stability_scale(p, score_stability);
             Duration::from_secs_f32(scaled)
         })
     }
 
     /// 'Node TM': scale the soft limit based on the fraction of nodes that have been spent searching
-    /// the current best move. If we've spent a large fraction of our nodes on the current best move,
-    /// then we should be more confident in it and spend less time, and vice versa.
-    const fn node_tm_scale(depth: i32, nodes: u64, best_move_nodes: u64) -> f32 {
+    /// the current best move.
+    fn node_tm_scale(p: &TimeParams, depth: i32, nodes: u64, best_move_nodes: u64) -> f32 {
         if depth < 4 || best_move_nodes == 0 {
             return 1.0;
         }
         let fraction = best_move_nodes as f32 / nodes as f32;
-        (NODE_TM_BASE - fraction) * NODE_TM_SCALE
+        (p.node_tm_base - fraction) * p.node_tm_scale
     }
 
     /// 'Best move stability': scale the soft limit based on how many iterations the best move has
-    /// remained the same. If the best move has been stable for many iterations, then we should be
-    /// more confident in it and spend less time, and vice versa.
-    const fn best_move_stability_scale(stability: u64) -> f32 {
-        (BEST_MOVE_TM_BASE - BEST_MOVE_TM_SCALE * (stability as f32)).max(BEST_MOVE_TM_MIN)
+    /// remained the same.
+    fn best_move_stability_scale(p: &TimeParams, stability: u64) -> f32 {
+        (p.best_move_tm_base - p.best_move_tm_scale * (stability as f32)).max(p.best_move_tm_min)
     }
 
     /// 'Score stability': scale the soft limit based on how stable the search score has been across
-    /// iterations. If the score has been stable for many iterations, then we should be more confident
-    /// in the search score and spend less time, and vice versa.
-    const fn score_stability_scale(stability: u64) -> f32 {
-        (SCORE_TM_BASE - SCORE_TM_SCALE * stability as f32).max(SCORE_TM_MIN)
+    /// iterations.
+    fn score_stability_scale(p: &TimeParams, stability: u64) -> f32 {
+        (p.score_tm_base - p.score_tm_scale * stability as f32).max(p.score_tm_min)
     }
 
-    fn calc_time_limits(fischer: FischerTime, fm_clock: usize) -> (Duration, Duration) {
+    fn calc_time_limits(p: &TimeParams, fischer: FischerTime, fm_clock: usize) -> (Duration, Duration) {
         let (time, inc) = (fischer.0, fischer.1 as f64);
         let max_time = time.saturating_sub(UCI_OVERHEAD_MS);
-        // Credit to Reckless for this formula for calculating the hard/soft bounds
         let soft_scale =
-            SOFT_TM_BASE + SOFT_TM_SCALE * (1.0 - (-SOFT_TM_FM_SCALE * fm_clock as f64).exp());
-        let soft_bound = (soft_scale * max_time as f64 + SOFT_TM_INC_SCALE * inc) as u64;
+            p.soft_tm_base + p.soft_tm_scale * (1.0 - (-p.soft_tm_fm_scale * fm_clock as f64).exp());
+        let soft_bound = (soft_scale * max_time as f64 + p.soft_tm_inc_scale * inc) as u64;
         let hard_bound =
-            ((HARD_TM_SCALE * max_time as f64 + HARD_TM_INC_SCALE * inc) as u64).min(max_time);
+            ((p.hard_tm_scale * max_time as f64 + p.hard_tm_inc_scale * inc) as u64).min(max_time);
         (
             Duration::from_millis(soft_bound),
             Duration::from_millis(hard_bound),

--- a/src/search/time.rs
+++ b/src/search/time.rs
@@ -4,6 +4,7 @@ use crate::search::parameters::*;
 
 pub const UCI_OVERHEAD_MS: u64 = 50;
 
+#[rustfmt::skip]
 pub struct TimeParams {
     pub soft_tm_base:        f64,
     pub soft_tm_scale:       f64,
@@ -22,6 +23,8 @@ pub struct TimeParams {
 }
 
 impl TimeParams {
+
+    #[rustfmt::skip]
     pub fn init() -> Self {
         Self {
             soft_tm_base:       tm_soft_base() as f64 / 1000.0,
@@ -99,8 +102,6 @@ impl SearchLimits {
         }
     }
 
-    /// Re-initialise the TimeParams from the current tunable values. Call at the top of the main
-    /// search function so that any tunable updates take effect immediately.
     pub fn init(&mut self) {
         self.time_params = TimeParams::init();
     }


### PR DESCRIPTION
```
Elo   | 0.48 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.27 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 22960 W: 5380 L: 5348 D: 12232
Penta | [76, 2476, 6341, 2514, 73]
```
https://openbench.nocturn9x.space/test/6936/