### PR TITLE
Minor movegen optimisations

### DIFF
--- a/src/board/castling.rs
+++ b/src/board/castling.rs
@@ -272,6 +272,18 @@ impl CastleTravel {
     pub const BQS: Bitboard = Bitboard(0x0E00000000000000);
 }
 
+pub const TRAVEL_MASKS: [[Bitboard; 2]; 2] = [
+    [CastleTravel::WKS, CastleTravel::WQS],
+    [CastleTravel::BKS, CastleTravel::BQS],
+];
+pub const SAFETY_MASKS: [[Bitboard; 2]; 2] = [
+    [CastleSafety::WKS, CastleSafety::WQS],
+    [CastleSafety::BKS, CastleSafety::BQS],
+];
+
+pub const KS_CASTLE_OFFSET: i8 = 2;
+pub const QS_CASTLE_OFFSET: i8 = -2;
+
 #[cfg(test)]
 mod tests {
     use crate::board::castling::Rights;

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -187,11 +187,11 @@ impl Board {
                 if let Some(ep_sq) = self.ep_sq {
                     let ep_bb = Bitboard::of_sq(ep_sq);
                     let attacker = sided_pawns & ep_bb.shift(-dirs[i]);
-                    if !attacker.is_empty() {
-                        let mv = Move::new(attacker.lsb(), ep_sq, MoveFlag::EnPassant);
-                        if self.is_legal(&mv) {
-                            moves.add_single(mv);
-                        }
+                    let mv = (!attacker.is_empty())
+                        .then(|| Move::new(attacker.lsb(), ep_sq, MoveFlag::EnPassant))
+                        .filter(|mv| self.is_legal(mv));
+                    if let Some(mv) = mv {
+                        moves.add_single(mv);
                     }
                 }
             }

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -1,5 +1,5 @@
 use crate::board::bitboard::Bitboard;
-use crate::board::castling::{CastleSafety, CastleTravel};
+
 use crate::board::file::File;
 use crate::board::moves::{Move, MoveFlag, MoveList};
 use crate::board::piece::Piece;
@@ -212,22 +212,21 @@ impl Board {
     }
 
     #[inline(always)]
-    #[rustfmt::skip]
     pub fn gen_standard_castle_moves(&self, side: Side, moves: &mut MoveList) {
-        let king_sq = self.king_sq(side);
+        const FLAGS: [MoveFlag; 2] = [MoveFlag::CastleK, MoveFlag::CastleQ];
+        const OFFSETS: [i8; 2] = [castling::KS_CASTLE_OFFSET, castling::QS_CASTLE_OFFSET];
+
         let occ = self.occ();
-        if self.has_kingside_rights(side) {
-            let travel_mask = if side == White { CastleTravel::WKS } else { CastleTravel::BKS };
-            let safety_mask = if side == White { CastleSafety::WKS } else { CastleSafety::BKS };
-            if (occ & travel_mask).is_empty() && (self.threats & safety_mask).is_empty() {
-                moves.add_move(king_sq, Square(king_sq.0 + 2), MoveFlag::CastleK);
-            }
-        }
-        if self.has_queenside_rights(side) {
-            let travel_mask = if side == White { CastleTravel::WQS } else { CastleTravel::BQS };
-            let safety_mask = if side == White { CastleSafety::WQS } else { CastleSafety::BQS };
-            if (occ & travel_mask).is_empty() && (self.threats & safety_mask).is_empty() {
-                moves.add_move(king_sq, Square(king_sq.0 - 2), MoveFlag::CastleQ);
+        let king_sq = self.king_sq(side);
+        let has_rights = [self.has_kingside_rights(side), self.has_queenside_rights(side)];
+
+        for i in 0..2 {
+            if has_rights[i] {
+                let travel_mask = castling::TRAVEL_MASKS[side][i];
+                let safety_mask = castling::SAFETY_MASKS[side][i];
+                if (occ & travel_mask).is_empty() && (self.threats & safety_mask).is_empty() {
+                    moves.add_move(king_sq, king_sq.shift(OFFSETS[i]), FLAGS[i]);
+                }
             }
         }
     }

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -168,38 +168,30 @@ impl Board {
         // Captures (standard captures, promo captures, and en passant).
         if filter.gen_captures() {
             let filter_mask = filter_mask & self.them();
-            let up_right = up + Square::RIGHT;
-            let up_left = up + Square::LEFT;
-            let right_pin_mask = ray::relative_diagonal(side, king_sq);
-            let left_pin_mask = ray::relative_diagonal(!side, king_sq);
+            let dirs = [up + Square::RIGHT, up + Square::LEFT];
+            let pin_masks = [ray::relative_diagonal(side, king_sq), ray::relative_diagonal(!side, king_sq)];
+            let shift_masks = [!File::H.to_bb(), !File::A.to_bb()];
 
-            // Pawns which are capable of capturing left/right (not pinned unless capturing along
-            // the pin ray, and not on the edge of the board).
-            let left_pawns = pawns & (!pinned | left_pin_mask) & !File::A.to_bb();
-            let right_pawns = pawns & (!pinned | right_pin_mask) & !File::H.to_bb();
+            for i in 0..2 {
+                // Pawns which are capable of capturing in the given direction (not pinned unless
+                // capturing along the pin ray, and not on the edge of the board).
+                let sided_pawns = pawns & (!pinned | pin_masks[i]) & shift_masks[i];
 
-            // Non-promotion captures
-            let left_caps = (left_pawns & !seventh_rank).shift(up_left);
-            let right_caps = (right_pawns & !seventh_rank).shift(up_right);
+                let non_promo_captures = (sided_pawns & !seventh_rank).shift(dirs[i]);
+                moves.add_pawn_moves(non_promo_captures & filter_mask, dirs[i], MoveFlag::Standard);
 
-            moves.add_pawn_moves(right_caps & filter_mask, up_right, MoveFlag::Standard);
-            moves.add_pawn_moves(left_caps & filter_mask, up_left, MoveFlag::Standard);
+                let promo_captures = (sided_pawns & seventh_rank).shift(dirs[i]);
+                moves.add_pawn_promos(promo_captures & filter_mask, dirs[i]);
 
-            // Promotion captures
-            let right_cap_promos = (right_pawns & seventh_rank).shift(up_right);
-            let left_cap_promos = (left_pawns & seventh_rank).shift(up_left);
-            moves.add_pawn_promos(left_cap_promos & filter_mask, up_left);
-            moves.add_pawn_promos(right_cap_promos & filter_mask, up_right);
-
-            // En passant
-            if let Some(ep_sq) = self.ep_sq {
-                let ep_bb = Bitboard::of_sq(ep_sq);
-                let right_attacker = right_pawns & ep_bb.shift(-up_right);
-                let left_attacker = left_pawns & ep_bb.shift(-up_left);
-                for pawn in right_attacker | left_attacker {
-                    let mv = Move::new(pawn, ep_sq, MoveFlag::EnPassant);
-                    if self.is_legal(&mv) {
-                        moves.add_single(mv);
+                // En passant.
+                if let Some(ep_sq) = self.ep_sq {
+                    let ep_bb = Bitboard::of_sq(ep_sq);
+                    let attacker = sided_pawns & ep_bb.shift(-dirs[i]);
+                    if !attacker.is_empty() {
+                        let mv = Move::new(attacker.lsb(), ep_sq, MoveFlag::EnPassant);
+                        if self.is_legal(&mv) {
+                            moves.add_single(mv);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
```
Benchmark 1: ./dev/hobbes-chess-engine bench
  Time (mean ± σ):     946.3 ms ±   1.7 ms    [User: 937.1 ms, System: 7.7 ms]
  Range (min … max):   943.5 ms … 948.6 ms    10 runs
 
Benchmark 2: ./main/hobbes-chess-engine bench
  Time (mean ± σ):      1.014 s ±  0.002 s    [User: 1.004 s, System: 0.008 s]
  Range (min … max):    1.010 s …  1.018 s    10 runs
 
Summary
  ./dev/hobbes-chess-engine bench ran
    1.07 ± 0.00 times faster than ./main/hobbes-chess-engine bench
```
```
Elo   | -0.49 +- 1.24 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | 3.02 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 84712 W: 20183 L: 20303 D: 44226
Penta | [514, 9959, 21562, 9775, 546]
```
https://openbench.nocturn9x.space/test/6977/