### PR TITLE
Optimise zobrist hash updates

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -174,18 +174,7 @@ impl Board {
         self.pcs[sq] = if cur == Some(pc) { None } else { Some(pc) };
 
         let hash = Keys::sq(pc, side, sq);
-        self.hashes.update_hash(hash);
-        if pc == Piece::Pawn {
-            self.hashes.update_pawn_hash(hash);
-        } else {
-            self.hashes.update_non_pawn_hash(side, hash);
-            if pc.is_major() {
-                self.hashes.update_major_hash(hash);
-            }
-            if pc.is_minor() {
-                self.hashes.update_minor_hash(hash);
-            }
-        }
+        self.hashes.update_piece(pc, side, hash);
     }
 
     /// Toggles a piece off `from` and on to `to` in a single call.

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -169,7 +169,10 @@ impl Board {
         if filter.gen_captures() {
             let filter_mask = filter_mask & self.them();
             let dirs = [up + Square::RIGHT, up + Square::LEFT];
-            let pin_masks = [ray::relative_diagonal(side, king_sq), ray::relative_diagonal(!side, king_sq)];
+            let pin_masks = [
+                ray::relative_diagonal(side, king_sq),
+                ray::relative_diagonal(!side, king_sq),
+            ];
             let shift_masks = [!File::H.to_bb(), !File::A.to_bb()];
 
             for i in 0..2 {
@@ -178,7 +181,11 @@ impl Board {
                 let sided_pawns = pawns & (!pinned | pin_masks[i]) & shift_masks[i];
 
                 let non_promo_captures = (sided_pawns & !seventh_rank).shift(dirs[i]);
-                moves.add_pawn_moves(non_promo_captures & filter_mask, dirs[i], MoveFlag::Standard);
+                moves.add_pawn_moves(
+                    non_promo_captures & filter_mask,
+                    dirs[i],
+                    MoveFlag::Standard,
+                );
 
                 let promo_captures = (sided_pawns & seventh_rank).shift(dirs[i]);
                 moves.add_pawn_promos(promo_captures & filter_mask, dirs[i]);
@@ -218,7 +225,10 @@ impl Board {
 
         let occ = self.occ();
         let king_sq = self.king_sq(side);
-        let has_rights = [self.has_kingside_rights(side), self.has_queenside_rights(side)];
+        let has_rights = [
+            self.has_kingside_rights(side),
+            self.has_queenside_rights(side),
+        ];
 
         for i in 0..2 {
             if has_rights[i] {

--- a/src/board/zobrist.rs
+++ b/src/board/zobrist.rs
@@ -46,6 +46,22 @@ pub const KEYS: Keys = {
     unsafe { std::mem::transmute(zobrist) }
 };
 
+/// Bit flags indicating which sub-hashes a piece type contributes to.
+const PAWN_FLAG: u8 = 1 << 0;
+const NON_PAWN_FLAG: u8 = 1 << 1;
+const MAJOR_FLAG: u8 = 1 << 2;
+const MINOR_FLAG: u8 = 1 << 3;
+
+/// Precomputed hash update flags indexed by piece type.
+const HASH_FLAGS: [u8; 6] = [
+    PAWN_FLAG,                               // Pawn -> pawn only
+    NON_PAWN_FLAG | MINOR_FLAG,              // Knight -> non_pawn + minor
+    NON_PAWN_FLAG | MINOR_FLAG,              // Bishop -> non_pawn + minor
+    NON_PAWN_FLAG | MAJOR_FLAG,              // Rook  -> non_pawn + major
+    NON_PAWN_FLAG | MAJOR_FLAG,              // Queen -> non_pawn + major
+    NON_PAWN_FLAG | MAJOR_FLAG | MINOR_FLAG, // King -> non_pawn + major + minor
+];
+
 impl Hashes {
     pub fn new(board: &Board) -> Self {
         Self {
@@ -65,20 +81,21 @@ impl Hashes {
         self.board ^= hash;
     }
 
-    pub fn update_pawn_hash(&mut self, hash: u64) {
-        self.pawn ^= hash;
-    }
+    /// Updates all relevant sub-hashes for a piece toggle in one go.
+    #[inline(always)]
+    pub fn update_piece(&mut self, pc: Piece, side: Side, hash: u64) {
+        let flags = HASH_FLAGS[pc as usize];
+        self.board ^= hash;
 
-    pub fn update_non_pawn_hash(&mut self, side: Side, hash: u64) {
-        self.non_pawn[side] ^= hash;
-    }
+        let pawn_mask = -((flags & PAWN_FLAG != 0) as i64) as u64;
+        let non_pawn_mask = -((flags & NON_PAWN_FLAG != 0) as i64) as u64;
+        let major_mask = -((flags & MAJOR_FLAG != 0) as i64) as u64;
+        let minor_mask = -((flags & MINOR_FLAG != 0) as i64) as u64;
 
-    pub fn update_major_hash(&mut self, hash: u64) {
-        self.major ^= hash;
-    }
-
-    pub fn update_minor_hash(&mut self, hash: u64) {
-        self.minor ^= hash;
+        self.pawn ^= hash & pawn_mask;
+        self.non_pawn[side] ^= hash & non_pawn_mask;
+        self.major ^= hash & major_mask;
+        self.minor ^= hash & minor_mask;
     }
 
     pub const fn hash(&self) -> u64 {


### PR DESCRIPTION
```
➜  hobbes sudo nice -n 40 ~/.cargo/bin/hyperfine "./dev/hobbes-chess-engine bench" "./main/hobbes-chess-engine bench" --warmup 40
Password:
Benchmark 1: ./dev/hobbes-chess-engine bench
  Time (mean ± σ):     933.6 ms ±   3.6 ms    [User: 924.2 ms, System: 7.8 ms]
  Range (min … max):   925.7 ms … 938.8 ms    10 runs
 
Benchmark 2: ./main/hobbes-chess-engine bench
  Time (mean ± σ):     942.5 ms ±   2.7 ms    [User: 933.1 ms, System: 7.8 ms]
  Range (min … max):   939.8 ms … 948.8 ms    10 runs
 
Summary
  ./dev/hobbes-chess-engine bench ran
    1.01 ± 0.00 times faster than ./main/hobbes-chess-engine bench
```