### PR TITLE
Fix transposition table mate scores

### DIFF
--- a/src/search/score.rs
+++ b/src/search/score.rs
@@ -55,9 +55,9 @@ pub const fn to_tt(score: i32, ply: usize) -> i32 {
     if !is_mate(score) {
         score
     } else if score > 0 {
-        score - ply as i32
-    } else {
         score + ply as i32
+    } else {
+        score - ply as i32
     }
 }
 
@@ -68,9 +68,9 @@ pub const fn to_search(score: i32, ply: usize) -> i32 {
     if !is_mate(score) {
         score
     } else if score > 0 {
-        score + ply as i32
-    } else {
         score - ply as i32
+    } else {
+        score + ply as i32
     }
 }
 


### PR DESCRIPTION
```
Elo   | -0.33 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 65702 W: 15621 L: 15684 D: 34397
Penta | [226, 7243, 17950, 7232, 200]
```
https://openbench.nocturn9x.space/test/7052/