### PR TITLE
Stop returning scores outside of [MIN, MAX] range

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -845,8 +845,8 @@ fn alpha_beta<NODE: NodeType>(
     }
 
     // Checkmate / Stalemate Detection
-    if legal_moves == 0 {
-        return if singular_search {
+    if searched_moves == 0 {
+        return if legal_moves > 0 {
             alpha
         } else if in_check {
             mated_in(ply)
@@ -867,6 +867,8 @@ fn alpha_beta<NODE: NodeType>(
     if !singular_search && !td.hard_limit_reached(){
         td.tt.insert(board.hash_with_50mr_bucket(), best_move, best_score, raw_eval, depth, ply, flag, tt_pv);
     }
+
+    debug_assert!(best_score > score::MIN && best_score < score::MAX);
 
     best_score
 }


### PR DESCRIPTION
```
Elo   | -1.11 +- 2.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.13 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 27648 W: 6590 L: 6678 D: 14380
Penta | [106, 3342, 6986, 3314, 76]
```
https://openbench.nocturn9x.space/test/7054/