### PR TITLE
Exit aspiration loop on mate scores

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -85,7 +85,7 @@ pub fn search(board: &Board, td: &mut ThreadData) -> (Move, i32) {
             prev_mv = td.best_move;
             prev_score = score;
 
-            if td.should_stop(Hard) {
+            if td.should_stop(Hard) || is_mate(score) {
                 break;
             }
 


### PR DESCRIPTION
```
Elo   | 0.86 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17002 W: 4043 L: 4001 D: 8958
Penta | [51, 1858, 4641, 1900, 51]
```
https://openbench.nocturn9x.space/test/7055/

bench 1573379