### PR TITLE
Stop storing valid TT score in early static eval store

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -257,7 +257,7 @@ fn alpha_beta<NODE: NodeType>(
             td.nnue.evaluate(board)
         };
         if !tt_hit {
-            td.tt.insert(board.hash_with_50mr_bucket(), Move::NONE, 0, raw_eval, depth, ply, TTFlag::None, tt_pv);
+            td.tt.insert(board.hash_with_50mr_bucket(), Move::NONE, score::MIN, raw_eval, depth, ply, TTFlag::None, tt_pv);
         }
         correction = td.correction_history.correction(board, &td.stack, ply);
         static_eval = raw_eval + correction;
@@ -968,7 +968,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
             td.tt.insert(
                 board.hash_with_50mr_bucket(),
                 Move::NONE,
-                0,
+                score::MIN,
                 raw_eval,
                 0,
                 ply,


### PR DESCRIPTION
```
Elo   | -0.13 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.52 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 43538 W: 10222 L: 10238 D: 23078
Penta | [117, 5196, 11172, 5154, 130]
```
https://openbench.nocturn9x.space/test/7068/