### PR TITLE
Make transposition table atomic

### DIFF
--- a/src/search/tt.rs
+++ b/src/search/tt.rs
@@ -2,6 +2,7 @@ use crate::board::moves::Move;
 use crate::search::score;
 use crate::search::score::{to_search, to_tt};
 use std::mem::size_of;
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering::Relaxed};
 
 /// The transposition table is a lookup table that stores the results of previously searched
 /// positions, including the search depth, the score, the best move found, and other relevant
@@ -14,17 +15,55 @@ const BUCKET_SIZE: usize = size_of::<Bucket>();
 const AGE_CYCLE: u8 = 1 << 5;
 const AGE_MASK: u8 = AGE_CYCLE - 1;
 
+const _: () = assert!(BUCKET_SIZE == 32);
+
 pub struct TranspositionTable {
     table: Vec<Bucket>,
     size_mb: usize,
     size: usize,
-    age: u8,
+    age: AtomicU8,
 }
 
-#[derive(Clone, Default)]
+/// The encoded data word of a default (empty) entry: `best_move = 0`, `score = eval = score::MIN`,
+/// `depth = 0`, and `flags = 0` (i.e. [`TTFlag::None`]). Used to initialise/clear buckets.
+const DEFAULT_ENTRY_DATA: u64 = {
+    let score = (score::MIN as i16) as u16 as u64;
+    let eval = (score::MIN as i16) as u16 as u64;
+    (score << 16) | (eval << 32)
+};
+
 #[repr(align(32))]
 struct Bucket {
-    entries: [Entry; ENTRIES_PER_BUCKET],
+    data: [AtomicU64; ENTRIES_PER_BUCKET],
+    keys: AtomicU64,
+}
+
+impl Default for Bucket {
+    fn default() -> Bucket {
+        Bucket {
+            data: [
+                AtomicU64::new(DEFAULT_ENTRY_DATA),
+                AtomicU64::new(DEFAULT_ENTRY_DATA),
+                AtomicU64::new(DEFAULT_ENTRY_DATA),
+            ],
+            keys: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Bucket {
+    /// Load and unpack the three 16-bit keys from the packed keys word.
+    #[inline]
+    fn load_keys(&self) -> [u16; ENTRIES_PER_BUCKET] {
+        let k = self.keys.load(Relaxed);
+        [k as u16, (k >> 16) as u16, (k >> 32) as u16]
+    }
+
+    /// Pack the three 16-bit keys into a single word, leaving the top 16 bits unused.
+    #[inline]
+    fn pack_keys(keys: [u16; ENTRIES_PER_BUCKET]) -> u64 {
+        (keys[0] as u64) | ((keys[1] as u64) << 16) | ((keys[2] as u64) << 32)
+    }
 }
 
 #[derive(Clone)]
@@ -84,6 +123,31 @@ impl Default for Entry {
 }
 
 impl Entry {
+    /// Decode an entry from its 16-bit key and packed 64-bit data word.
+    #[inline]
+    fn from_parts(key: u16, data: u64) -> Entry {
+        Entry {
+            key,
+            best_move: data as u16,
+            score: (data >> 16) as i16,
+            eval: (data >> 32) as i16,
+            depth: (data >> 48) as u8,
+            flags: Flags {
+                data: (data >> 56) as u8,
+            },
+        }
+    }
+
+    /// Pack this entry's non-key payload into a single 64-bit data word.
+    #[inline]
+    fn to_data(&self) -> u64 {
+        (self.best_move as u64)
+            | ((self.score as u16 as u64) << 16)
+            | ((self.eval as u16 as u64) << 32)
+            | ((self.depth as u64) << 48)
+            | ((self.flags.data as u64) << 56)
+    }
+
     pub const fn best_move(&self) -> Move {
         Move(self.best_move)
     }
@@ -128,8 +192,8 @@ impl TranspositionTable {
     /// the table is calculated based on the size of each bucket and the number of entries per bucket.
     pub fn new(size_mb: usize) -> TranspositionTable {
         let size = size_mb * 1024 * 1024 / BUCKET_SIZE;
-        let table = vec![Bucket::default(); size];
-        let age = 0;
+        let table = (0..size).map(|_| Bucket::default()).collect();
+        let age = AtomicU8::new(0);
         TranspositionTable {
             table,
             size_mb,
@@ -142,34 +206,42 @@ impl TranspositionTable {
     /// and reset all entries to their default values.
     pub fn resize(&mut self, size_mb: usize) {
         let size = size_mb * 1024 * 1024 / BUCKET_SIZE;
-        self.table = vec![Bucket::default(); size];
+        self.table = (0..size).map(|_| Bucket::default()).collect();
         self.size_mb = size_mb;
         self.size = size;
     }
 
     /// Clear all entries in the transposition table by resetting them to their default values.
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .for_each(|entry| *entry = Bucket::default());
-        self.age = 0;
+        for bucket in self.table.iter() {
+            for word in &bucket.data {
+                word.store(DEFAULT_ENTRY_DATA, Relaxed);
+            }
+            bucket.keys.store(0, Relaxed);
+        }
+        self.age.store(0, Relaxed);
     }
 
     /// Increment the age of the transposition table. This is used to track the relative age of the
     /// entries in the table, which is a factor in the entry replacement scheme.
-    pub const fn birthday(&mut self) {
-        self.age = (self.age + 1) & AGE_MASK;
+    pub fn birthday(&self) {
+        let next = (self.age.load(Relaxed) + 1) & AGE_MASK;
+        self.age.store(next, Relaxed);
     }
 
     /// Probe the transposition table for an entry with the given hash. The hash is used as an index
     /// into a bucket, and the entries in the bucket are searched for a matching key.
-    pub fn probe(&self, hash: u64) -> Option<&Entry> {
+    pub fn probe(&self, hash: u64) -> Option<Entry> {
         let idx = self.idx(hash);
         let bucket = &self.table[idx];
-        bucket
-            .entries
-            .iter()
-            .find(|&entry| entry.validate_key(hash))
+        let key_part = hash as u16;
+        let keys = bucket.load_keys();
+        for (i, &key) in keys.iter().enumerate() {
+            if key == key_part {
+                return Some(Entry::from_parts(key, bucket.data[i].load(Relaxed)));
+            }
+        }
+        None
     }
 
     /// Insert a new entry into the transposition table. We iterate through the entries in the bucket
@@ -177,7 +249,7 @@ impl TranspositionTable {
     /// that considers both search depth and entry age.
     #[allow(clippy::too_many_arguments)]
     pub fn insert(
-        &mut self,
+        &self,
         hash: u64,
         best_move: Move,
         score: i32,
@@ -188,14 +260,21 @@ impl TranspositionTable {
         pv: bool,
     ) {
         let idx = self.idx(hash);
-        let tt_age = self.age;
+        let tt_age = self.age.load(Relaxed);
         let key_part = hash as u16;
-        let cluster = &mut self.table[idx];
+        let cluster = &self.table[idx];
+
+        let mut keys = cluster.load_keys();
+        let entries = [
+            Entry::from_parts(keys[0], cluster.data[0].load(Relaxed)),
+            Entry::from_parts(keys[1], cluster.data[1].load(Relaxed)),
+            Entry::from_parts(keys[2], cluster.data[2].load(Relaxed)),
+        ];
 
         let mut index = 0;
         let mut minimum = i32::MAX;
 
-        for (i, entry) in cluster.entries.iter_mut().enumerate() {
+        for (i, entry) in entries.iter().enumerate() {
             if entry.key == key_part || entry.flag() == TTFlag::None {
                 index = i;
                 break;
@@ -208,7 +287,7 @@ impl TranspositionTable {
             }
         }
 
-        let entry = &mut cluster.entries[index];
+        let entry = &entries[index];
 
         let key_match = key_part == entry.key;
         let mv = if !best_move.exists() && key_match {
@@ -225,12 +304,18 @@ impl TranspositionTable {
             return;
         }
 
-        entry.key = key_part;
-        entry.best_move = mv.0;
-        entry.score = to_tt(score, ply) as i16;
-        entry.eval = static_eval as i16;
-        entry.depth = depth as u8;
-        entry.flags = Flags::new(flag, pv, tt_age);
+        let new_entry = Entry {
+            key: key_part,
+            best_move: mv.0,
+            score: to_tt(score, ply) as i16,
+            eval: static_eval as i16,
+            depth: depth as u8,
+            flags: Flags::new(flag, pv, tt_age),
+        };
+
+        cluster.data[index].store(new_entry.to_data(), Relaxed);
+        keys[index] = key_part;
+        cluster.keys.store(Bucket::pack_keys(keys), Relaxed);
     }
 
     /// For efficient indexing into an arbitrarily-sized hash table, we use Lemire's multiplication
@@ -250,8 +335,11 @@ impl TranspositionTable {
     pub fn fill(&self) -> usize {
         let mut fill = 0;
         for bucket in self.table.iter().take(1000 / ENTRIES_PER_BUCKET) {
-            for entry in &bucket.entries {
-                if entry.flags.bound() != TTFlag::None {
+            for word in &bucket.data {
+                let flags = Flags {
+                    data: (word.load(Relaxed) >> 56) as u8,
+                };
+                if flags.bound() != TTFlag::None {
                     fill += 1;
                 }
             }

--- a/src/search/tt.rs
+++ b/src/search/tt.rs
@@ -17,6 +17,11 @@ const AGE_MASK: u8 = AGE_CYCLE - 1;
 
 const _: () = assert!(BUCKET_SIZE == 32);
 
+const SCORE_SHIFT: u32 = 16;
+const EVAL_SHIFT: u32 = 32;
+const DEPTH_SHIFT: u32 = 48;
+const FLAGS_SHIFT: u32 = 56;
+
 pub struct TranspositionTable {
     table: Vec<Bucket>,
     size_mb: usize,
@@ -129,11 +134,11 @@ impl Entry {
         Entry {
             key,
             best_move: data as u16,
-            score: (data >> 16) as i16,
-            eval: (data >> 32) as i16,
-            depth: (data >> 48) as u8,
+            score: (data >> SCORE_SHIFT) as i16,
+            eval: (data >> EVAL_SHIFT) as i16,
+            depth: (data >> DEPTH_SHIFT) as u8,
             flags: Flags {
-                data: (data >> 56) as u8,
+                data: (data >> FLAGS_SHIFT) as u8,
             },
         }
     }
@@ -142,10 +147,10 @@ impl Entry {
     #[inline]
     fn to_data(&self) -> u64 {
         (self.best_move as u64)
-            | ((self.score as u16 as u64) << 16)
-            | ((self.eval as u16 as u64) << 32)
-            | ((self.depth as u64) << 48)
-            | ((self.flags.data as u64) << 56)
+            | ((self.score as u16 as u64) << SCORE_SHIFT)
+            | ((self.eval as u16 as u64) << EVAL_SHIFT)
+            | ((self.depth as u64) << DEPTH_SHIFT)
+            | ((self.flags.data as u64) << FLAGS_SHIFT)
     }
 
     pub const fn best_move(&self) -> Move {
@@ -337,7 +342,7 @@ impl TranspositionTable {
         for bucket in self.table.iter().take(1000 / ENTRIES_PER_BUCKET) {
             for word in &bucket.data {
                 let flags = Flags {
-                    data: (word.load(Relaxed) >> 56) as u8,
+                    data: (word.load(Relaxed) >> FLAGS_SHIFT) as u8,
                 };
                 if flags.bound() != TTFlag::None {
                     fill += 1;

--- a/src/search/tt.rs
+++ b/src/search/tt.rs
@@ -29,12 +29,11 @@ pub struct TranspositionTable {
     age: AtomicU8,
 }
 
-/// The encoded data word of a default (empty) entry: `best_move = 0`, `score = eval = score::MIN`,
-/// `depth = 0`, and `flags = 0` (i.e. [`TTFlag::None`]). Used to initialise/clear buckets.
-const DEFAULT_ENTRY_DATA: u64 = {
+/// Pack the default score and eval values into their appropriate positions in the 64-bit data word.
+const DEFAULT_ENTRY_RAW: u64 = {
     let score = (score::MIN as i16) as u16 as u64;
     let eval = (score::MIN as i16) as u16 as u64;
-    (score << 16) | (eval << 32)
+    (score << SCORE_SHIFT) | (eval << EVAL_SHIFT)
 };
 
 #[repr(align(32))]
@@ -47,9 +46,9 @@ impl Default for Bucket {
     fn default() -> Bucket {
         Bucket {
             data: [
-                AtomicU64::new(DEFAULT_ENTRY_DATA),
-                AtomicU64::new(DEFAULT_ENTRY_DATA),
-                AtomicU64::new(DEFAULT_ENTRY_DATA),
+                AtomicU64::new(DEFAULT_ENTRY_RAW),
+                AtomicU64::new(DEFAULT_ENTRY_RAW),
+                AtomicU64::new(DEFAULT_ENTRY_RAW),
             ],
             keys: AtomicU64::new(0),
         }
@@ -220,7 +219,7 @@ impl TranspositionTable {
     pub fn clear(&mut self) {
         for bucket in self.table.iter() {
             for word in &bucket.data {
-                word.store(DEFAULT_ENTRY_DATA, Relaxed);
+                word.store(DEFAULT_ENTRY_RAW, Relaxed);
             }
             bucket.keys.store(0, Relaxed);
         }


### PR DESCRIPTION
```
Elo   | -0.83 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.11 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 13848 W: 3276 L: 3309 D: 7263
Penta | [27, 1438, 4034, 1391, 34]
```
https://openbench.nocturn9x.space/test/7230/