### PR TITLE
Stop checking time management in helper threads

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -880,7 +880,7 @@ fn alpha_beta<NODE: NodeType>(
     }
 
     // Store the best move and score in the transposition table
-    if !singular_search && !td.hard_limit_reached(){
+    if !singular_search && !td.should_stop(Hard) {
         td.tt().insert(board.hash_with_50mr_bucket(), best_move, best_score, raw_eval, depth, ply, flag, tt_pv);
     }
 
@@ -1103,7 +1103,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     }
 
     // Write to transposition table
-    if !td.hard_limit_reached() {
+    if !td.should_stop(Hard) {
         td.tt().insert(
             board.hash_with_50mr_bucket(),
             best_move,

--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -185,7 +185,7 @@ impl ThreadData {
         stop
     }
 
-    pub fn soft_limit_reached(&self) -> bool {
+    fn soft_limit_reached(&self) -> bool {
         let best_move_nodes = self.node_table.get(&self.best_move);
         let best_move_stability = self.best_move_stability as u64;
         let score_stability = self.score_stability as u64;
@@ -217,7 +217,7 @@ impl ThreadData {
         false
     }
 
-    pub fn hard_limit_reached(&self) -> bool {
+    fn hard_limit_reached(&self) -> bool {
         if let Some(hard_nodes) = self.limits.hard_nodes {
             if self.nodes() >= hard_nodes {
                 return true;


### PR DESCRIPTION
```
Elo   | 1.95 +- 3.27 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11430 W: 2731 L: 2667 D: 6032
Penta | [34, 1348, 2880, 1426, 27]
```
https://openbench.nocturn9x.space/test/7284/