### PR TITLE
Allow double and triple extensions in PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -460,8 +460,12 @@ fn alpha_beta<NODE: NodeType>(
             if singular_score < s_beta {
                 // If the reduced search fails to beat s_beta, then we assume the TT move is singular.
                 extension = 1;
-                extension += (!pv_node && singular_score < s_beta - se_dext_margin(is_quiet)) as i32;
-                extension += (!pv_node && is_quiet && singular_score < s_beta - se_text_margin(is_quiet)) as i32;
+
+                let double_margin = se_dext_margin(is_quiet) + 100 * pv_node as i32;
+                extension += (singular_score < s_beta - double_margin) as i32;
+
+                let triple_margin = se_text_margin(is_quiet) + 100 * pv_node as i32;
+                extension += (is_quiet && singular_score < s_beta - triple_margin) as i32;
             } else if s_beta >= beta {
                 return (s_beta * s_depth + beta) / (s_depth + 1);
             } else if tt_score >= beta {

--- a/src/search.rs
+++ b/src/search.rs
@@ -461,10 +461,10 @@ fn alpha_beta<NODE: NodeType>(
                 // If the reduced search fails to beat s_beta, then we assume the TT move is singular.
                 extension = 1;
 
-                let double_margin = se_dext_margin(is_quiet) + 100 * pv_node as i32;
+                let double_margin = se_dext_margin(is_quiet) + se_dext_pv_margin() * pv_node as i32;
                 extension += (singular_score < s_beta - double_margin) as i32;
 
-                let triple_margin = se_text_margin(is_quiet) + 100 * pv_node as i32;
+                let triple_margin = se_text_margin(is_quiet) + se_text_pv_margin() * pv_node as i32;
                 extension += (is_quiet && singular_score < s_beta - triple_margin) as i32;
             } else if s_beta >= beta {
                 return (s_beta * s_depth + beta) / (s_depth + 1);

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -87,6 +87,8 @@ tunable_params! {
     se_beta_noisy_div            = 54, 40..=100,           true;
     se_dext_noisy_margin         = 10, 0..=30,             true;
     se_text_noisy_margin         = 48, 20..=120,           true;
+    se_dext_pv_margin            = 100, 0..=200,           true;
+    se_text_pv_margin            = 100, 0..=200,           true;
     ldse_max_depth               = 7, 1..=12,              false;
     ldse_margin                  = 27, 0..=80,             true;
     ldse_dext_tt_depth_offset    = 3, 1..=5,               false;


### PR DESCRIPTION
```
Elo   | 1.83 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 4.00]
Games | N: 58506 W: 14212 L: 13904 D: 30390
Penta | [221, 6778, 14935, 7110, 209]
```
https://openbench.nocturn9x.space/test/7473/
```
Elo   | 2.19 +- 1.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 34432 W: 8151 L: 7934 D: 18347
Penta | [20, 3821, 9322, 4028, 25]
```
https://openbench.nocturn9x.space/test/7477/