### PR TITLE
Allow q-search futility pruning in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1039,8 +1039,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
 
         // Futility Pruning
         // Skip captures that don't win material when the static eval is far below alpha.
-        if !in_check
-            && !is_mate_score
+        if !is_mate_score
             && !is_killer
             && futility_margin <= alpha
             && !see::see(board, &mv, 1, Pruning)


### PR DESCRIPTION
```
Elo   | 1.68 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 4.00]
Games | N: 73378 W: 17698 L: 17344 D: 38336
Penta | [260, 8622, 18607, 8904, 296]
```
https://openbench.nocturn9x.space/test/7506/

```
Elo   | 1.26 +- 1.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.57 (-2.25, 2.89) [0.00, 3.00]
Games | N: 97692 W: 23070 L: 22717 D: 51905
Penta | [88, 11223, 25875, 11568, 92]
```
https://openbench.nocturn9x.space/test/7511/