### PR TITLE
Increase max RFP depth if improving

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -340,7 +340,7 @@ fn alpha_beta<NODE: NodeType>(
             - rfp_improving_scale() * improving as i32
             - rfp_opp_worsening_scale() * opponent_worsening as i32
             - rfp_tt_move_noisy_scale() * tt_move_noisy as i32;
-        if depth <= rfp_max_depth() && static_eval - futility_margin >= beta {
+        if depth <= rfp_max_depth() + 2 * improving as i32 && static_eval - futility_margin >= beta {
             return lerp(beta, static_eval, rfp_lerp_factor());
         }
 


### PR DESCRIPTION
```
Elo   | 1.83 +- 1.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 4.00]
Games | N: 56306 W: 13493 L: 13197 D: 29616
Penta | [156, 6502, 14550, 6780, 165]
```
https://openbench.nocturn9x.space/test/7623/

```
Elo   | 1.57 +- 1.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.39 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31586 W: 7522 L: 7379 D: 16685
Penta | [17, 3525, 8565, 3670, 16]
```
https://openbench.nocturn9x.space/test/7629/

(we merge those)