### PR TITLE
Adjust singular beta based on history score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -447,9 +447,15 @@ fn alpha_beta<NODE: NodeType>(
             && tt_flag != Upper
             && tt_depth >= depth - se_tt_depth_offset() {
 
+            let pc = board.piece_at(tt_move.from()).unwrap();
+            let captured = board.captured(&tt_move);
+            let history_score = td.history
+                .history_score(board, &td.stack, &tt_move, ply, threats, pc, captured);
+
             let is_quiet = board.captured(&tt_move).is_some();
             let (s_beta_base, s_beta_scale, s_beta_div) = se_config(is_quiet);
-            let s_beta_margin = (s_beta_base + s_beta_scale * (tt_pv && !pv_node) as i32) * depth / s_beta_div;
+            let s_beta_margin = (s_beta_base + s_beta_scale * (tt_pv && !pv_node) as i32) * depth / s_beta_div
+                + (history_score / 1024).clamp(-depth / 4, depth / 4);
             let s_beta = (tt_score - s_beta_margin).max(-score::MATE + 1);
             let s_depth = (depth - se_depth_offset()) / se_depth_divisor();
 


### PR DESCRIPTION
```
Elo   | 2.56 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33268 W: 8014 L: 7769 D: 17485
Penta | [109, 3797, 8578, 4040, 110]
```
https://openbench.nocturn9x.space/test/7648/

```
Elo   | 3.03 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 4.00]
Games | N: 21426 W: 5060 L: 4873 D: 11493
Penta | [15, 2384, 5733, 2561, 20]
```
https://openbench.nocturn9x.space/test/7651/

bench 1640735