### PR TITLE
Only update history on fail highs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -778,7 +778,7 @@ fn alpha_beta<NODE: NodeType>(
     // Update history tables
     // When the best move causes a beta cut-off, we update the history tables to reward the best move
     // and punish the other searched moves. Doing so will improve move ordering in subsequent searches.
-    if best_move.exists() {
+    if flag == Lower {
         let pc = board.piece_at(best_move.from()).unwrap();
         let new_tt_move = tt_move.exists() && best_move != tt_move;
 


### PR DESCRIPTION
```
Elo   | 1.87 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 53908 W: 12967 L: 12677 D: 28264
Penta | [146, 6271, 13855, 6511, 171]
```
https://openbench.nocturn9x.space/test/7705/