### PR TITLE
Allow SEE pruning in PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -611,8 +611,7 @@ fn alpha_beta<NODE: NodeType>(
                 - tt_pv as i32 * lmr_depth * see_noisy_ttpv_scale()
                 + see_noisy_offset()).min(0)
         };
-        if !pv_node
-            && depth <= see_max_depth()
+        if depth <= see_max_depth()
             && to_threatened
             && searched_moves >= 1
             && !is_mate(best_score)


### PR DESCRIPTION
```
Elo   | 3.21 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 10728 W: 2602 L: 2503 D: 5623
Penta | [27, 1256, 2702, 1349, 30]
```
https://openbench.nocturn9x.space/test/7741/