### PR TITLE
Utilise `skip_quiets` in q-search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -959,12 +959,14 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     let mut tt_pv = pv_node;
     let mut tt_move = Move::NONE;
     let mut tt_eval = score::MIN;
+    let mut tt_move_noisy = false;
     if let Some(entry) = td.tt().probe(board.hash_with_50mr_bucket()) {
         tt_hit = true;
         tt_pv = tt_pv || entry.pv();
         tt_eval = entry.static_eval() as i32;
         if can_use_tt_move(board, &entry.best_move()) {
             tt_move = entry.best_move();
+            tt_move_noisy = board.is_noisy(&tt_move);
         }
         let score = entry.score(ply) as i32;
 
@@ -1009,12 +1011,13 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
         }
     }
 
-    let filter = if in_check {
-        MoveFilter::All
+    let skip_quiets = !in_check && (pv_node || !tt_move.exists() || tt_move_noisy);
+    let filter = if skip_quiets {
+        MoveFilter::Noisies
     } else {
         MoveFilter::Captures
     };
-    let mut move_picker = MovePicker::new_qsearch(tt_move, filter, ply, threats);
+    let mut move_picker = MovePicker::new_qsearch(tt_move, filter, ply, threats, skip_quiets);
 
     let mut legal_moves = 0;
     let mut searched_moves = 0;

--- a/src/search/movepicker.rs
+++ b/src/search/movepicker.rs
@@ -50,8 +50,14 @@ impl MovePicker {
         Self::init(tt_move, MoveFilter::Noisies, ply, threats, false, true)
     }
 
-    pub fn new_qsearch(tt_move: Move, filter: MoveFilter, ply: usize, threats: Bitboard) -> Self {
-        Self::init(tt_move, filter, ply, threats, true, false)
+    pub fn new_qsearch(
+        tt_move: Move,
+        filter: MoveFilter,
+        ply: usize,
+        threats: Bitboard,
+        skip_quiets: bool
+    ) -> Self {
+        Self::init(tt_move, filter, ply, threats, skip_quiets, false)
     }
 
     #[rustfmt::skip]


### PR DESCRIPTION
```
Elo   | 2.43 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34968 W: 8361 L: 8116 D: 18491
Penta | [81, 3971, 9148, 4190, 94]
```
https://openbench.nocturn9x.space/test/7749/

```
Elo   | 1.09 +- 1.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.85 (-2.25, 2.89) [0.00, 3.00]
Games | N: 45326 W: 10695 L: 10553 D: 24078
Penta | [31, 5080, 12294, 5232, 26]
```
https://openbench.nocturn9x.space/test/7750/

(we merge those)