### PR TITLE
Update correction history on detecting upcoming repetitions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -176,6 +176,11 @@ fn alpha_beta<NODE: NodeType>(
 
     if !root_node && alpha < 0 && board.has_upcoming_repetition(td, ply) {
         alpha = 0;
+        if !in_check {
+            let raw_eval = td.nnue.evaluate(board);
+            td.correction_history
+                .update_correction_history(board, &td.stack, depth, ply, raw_eval, 0);
+        }
         if alpha >= beta {
             return alpha;
         }
@@ -917,8 +922,18 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     debug_assert!(score::MIN < alpha && alpha < beta && beta < score::MAX);
     debug_assert!(pv_node || alpha == beta - 1);
 
+    // Determine if we are currently in check.
+    let threats = board.threats;
+    let in_check = threats.contains(board.our_king_sq());
+    td.stack[ply].threats = threats;
+
     if alpha < 0 && board.has_upcoming_repetition(td, ply) {
         alpha = 0;
+        if !in_check {
+            let raw_eval = td.nnue.evaluate(board);
+            td.correction_history
+                .update_correction_history(board, &td.stack, 0, ply, raw_eval, 0);
+        }
         if alpha >= beta {
             return alpha;
         }
@@ -948,11 +963,6 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     if ply >= MAX_PLY {
         return td.nnue.evaluate(board);
     }
-
-    // Determine if we are currently in check.
-    let threats = board.threats;
-    let in_check = threats.contains(board.our_king_sq());
-    td.stack[ply].threats = threats;
 
     // Transposition Table Lookup
     let mut tt_hit = false;

--- a/src/search.rs
+++ b/src/search.rs
@@ -177,9 +177,10 @@ fn alpha_beta<NODE: NodeType>(
     if !root_node && alpha < 0 && board.has_upcoming_repetition(td, ply) {
         alpha = 0;
         if !in_check {
-            let raw_eval = td.nnue.evaluate(board);
+            let static_eval = td.nnue.evaluate(board)
+                + td.correction_history.correction(board, &td.stack, ply);
             td.correction_history
-                .update_correction_history(board, &td.stack, depth, ply, raw_eval, 0);
+                .update_correction_history(board, &td.stack, depth, ply, static_eval, 0);
         }
         if alpha >= beta {
             return alpha;
@@ -930,9 +931,10 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
     if alpha < 0 && board.has_upcoming_repetition(td, ply) {
         alpha = 0;
         if !in_check {
-            let raw_eval = td.nnue.evaluate(board);
+            let static_eval = td.nnue.evaluate(board)
+                + td.correction_history.correction(board, &td.stack, ply);
             td.correction_history
-                .update_correction_history(board, &td.stack, 0, ply, raw_eval, 0);
+                .update_correction_history(board, &td.stack, 0, ply, static_eval, 0);
         }
         if alpha >= beta {
             return alpha;


### PR DESCRIPTION
```
Elo   | 2.58 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33128 W: 7987 L: 7741 D: 17400
Penta | [93, 3850, 8435, 4090, 96]
```
https://openbench.nocturn9x.space/test/7763/

```
Elo   | 4.56 +- 2.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14696 W: 3570 L: 3377 D: 7749
Penta | [8, 1596, 3949, 1785, 10]
```
https://openbench.nocturn9x.space/test/7765/