### PR TITLE
Update correction history on upcoming repetitions in q-search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -937,7 +937,7 @@ fn qs(board: &Board, td: &mut ThreadData, mut alpha: i32, beta: i32, ply: usize)
             let static_eval = td.nnue.evaluate(board)
                 + td.correction_history.correction(board, &td.stack, ply);
             td.correction_history
-                .update_correction_history(board, &td.stack, 0, ply, static_eval, 0);
+                .update_correction_history(board, &td.stack, 1, ply, static_eval, 0);
         }
         if alpha >= beta {
             return alpha;


### PR DESCRIPTION
```
Elo   | 1.13 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 21494 W: 5160 L: 5090 D: 11244
Penta | [62, 2572, 5415, 2630, 68]
```
https://openbench.nocturn9x.space/test/7770/